### PR TITLE
introduce type derivation

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1,0 +1,10 @@
+open Base
+
+type type_var = string
+
+type t =
+  (type_var, Types.typ, String.comparator_witness) Map.t
+
+let empty : t = Map.empty (module String)
+let find = Map.find
+let add key data = Map.add_exn ~key ~data

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -1,5 +1,4 @@
 open Base
-open Fialyzer
 
 let new_var =
   let i = ref 0 in

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -1,0 +1,37 @@
+open Base
+open Fialyzer
+
+let new_var =
+  let i = ref 0 in
+  fun () ->
+    Int.incr i;
+    Printf.sprintf "%s%02d" "v" !i
+
+let rec derive context = function
+  | Types.Val c ->
+     Ok (Types.TyConstant c, Types.Empty)
+  | Types.Var v ->
+     begin match Context.find context v with
+     | Some ty ->
+        Ok(ty, Types.Empty)
+     | None ->
+        Error ("unknown type variable: " ^ v)
+     end
+  | Types.App (f, [arg1]) ->
+     let open Result in
+     derive context f >>= fun (tyf, cf) ->
+     derive context arg1 >>= fun (ty1, c1) ->
+     begin match tyf with
+     | Types.Fun([ty_arg1], ty) ->
+        let beta = new_var() in
+        Ok(Types.TyVar beta, Types.Conj [cf; c1])
+     | _ ->
+        Error "expected function type"
+     end
+  | Types.Abs ([v], e) ->
+     let open Result in
+     let ty_v = new_var () in
+     derive (Context.add v (Types.TyVar ty_v) context) e >>= fun (ty_e, c) ->
+     Ok(Types.Fun([Types.TyVar ty_v], Types.Constraint(ty_e, c)), Types.Empty)
+  | other ->
+     Error (Printf.sprintf "unsupported type: %s" (Types.show_expr other))

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -1,4 +1,5 @@
 open Base
+open Types
 
 let new_var =
   let i = ref 0 in
@@ -20,13 +21,18 @@ let rec derive context = function
      let open Result in
      derive context f >>= fun (tyf, cf) ->
      derive context arg1 >>= fun (ty1, c1) ->
-     begin match tyf with
-     | Types.Fun([ty_arg1], ty) ->
-        let beta = new_var() in
-        Ok(Types.TyVar beta, Types.Conj [cf; c1])
-     | _ ->
-        Error "expected function type"
-     end
+     let alpha1 = new_var() in
+     let alpha = new_var() in
+     let beta = new_var() in
+     let constraints = [
+         Eq (tyf, Fun ([TyVar alpha1], TyVar alpha));
+         Subtype (TyVar beta, TyVar alpha);
+         Subtype (ty1, TyVar alpha1);
+         cf;
+         c1;
+       ]
+     in
+     Ok(TyVar beta, Conj constraints)
   | Types.Abs ([v], e) ->
      let open Result in
      let ty_v = new_var () in

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name fialyzer)
  (public_name fialyzer)
- (libraries obeam)
+ (libraries obeam base)
  (preprocess (pps ppx_deriving.std)))
 
 (env

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -32,6 +32,7 @@ type typ =
     | TyConstant of constant
 [@@deriving show]
 and constraint_ =
+    | Eq of typ * typ
     | Subtype of typ * typ
     | Conj of constraint_ list
     | Disj of constraint_ list

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -33,6 +33,7 @@ type typ =
     | TyConstant of constant
 [@@deriving show]
 and constraint_ =
+    | Eq of typ * typ
     | Subtype of typ * typ
     | Conj of constraint_ list
     | Disj of constraint_ list


### PR DESCRIPTION
introduce the function
```ocaml
val derive : Context.t -> expr -> (typ * constraint_) result
```

and support following rules
- [VAR]
- [ABS] (only one argument)
- [APP] (only one argument)

## examples

```ocaml
open Fialyzer
open Types
let type_inf expr =
  match Derivation.derive Context.empty expr with
  | Ok (ty, _) -> Printf.sprintf "%s :: %s" (show_expr expr) (show_typ ty) |> print_endline
  | Error msg -> failwith msg
      
let () =
  let x1 = "x1" in
  type_inf (Val (Int 1));
  type_inf (Abs ([x1], Val (Int 10)));
  let id = Abs ([x1], Var x1) in
  type_inf id;
  type_inf (App (id, [Val (Int 1)]));
  ()
```

```scheme
(Types.Val (Types.Int 1)) :: (Types.TyConstant (Types.Int 1))
(Types.Abs (["x1"], (Types.Val (Types.Int 10)))) :: (Types.Fun ([(Types.TyVar "v01")],
   (Types.Constraint ((Types.TyConstant (Types.Int 10)), Types.Empty))))
(Types.Abs (["x1"], (Types.Var "x1"))) :: (Types.Fun ([(Types.TyVar "v02")],
   (Types.Constraint ((Types.TyVar "v02"), Types.Empty))))
(Types.App ((Types.Abs (["x1"], (Types.Var "x1"))),
   [(Types.Val (Types.Int 1))])) :: (Types.TyVar "v04")
```