### PR TITLE
Feature/issue 13/constraint solver

### DIFF
--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1,37 +1,85 @@
-open Base
 open Ast_intf
+module List = Base.List
+module Map = Base.Map
+module String = Base.String
+module Result = Base.Result
 
 type ty_var = string
 type sol = (ty_var, typ, String.comparator_witness) Map.t
+         
+let init : sol = Map.empty (module String)
 
-(* 型 type_subst (X, τ_1) τ_2 := [X ↦ τ_1]τ_2 *)
-let rec type_subst ((x : ty_var) , (ty1 : typ)): typ -> typ = function
+(* type_subst (X, τ_1) τ_2 := [X ↦ τ_1]τ_2 *)
+let rec type_subst (x, ty1): typ -> typ = function
   | TyStruct tys ->
      TyStruct(List.map ~f:(type_subst (x, ty1)) tys)
   | TyFun (tys, ty) ->
      TyFun (List.map ~f:(type_subst (x, ty1)) tys, type_subst (x, ty1) ty)
   | TyUnion (ty_a, ty_b) ->
      TyUnion(type_subst (x, ty1) ty_a, type_subst (x, ty1) ty_b)
-  | TyConstraint (ty, c) ->
-     TyConstraint(type_subst (x, ty1) ty, type_subst_to_constraint (x, ty1) c)
+  | TyConstraint (ty, c) -> (* TODO: for constraint? *)
+     TyConstraint(type_subst (x, ty1) ty, c)
   | TyAny -> TyAny
   | TyNone -> TyNone
   | TyInteger -> TyInteger
   | TyAtom -> TyAtom
   | TyConstant const -> TyConstant const
-  | TyVar (v:ty_var) ->
-     if
-       String.equal x v
-     then ty1 else (TyVar v)
+  | TyVar v ->
+     if x = v then ty1 else (TyVar v)
 and type_subst_to_constraint (x, ty1) = function
   | _ ->
-     failwith "not implemented "
+     failwith "not implemented type_subst_to_constraint"
 
-let solve_eq sol ty1 ty2 =
+let type_subst_to_sol (x, ty) sol =
+  Map.map ~f:(type_subst (x, ty)) sol
+
+let add (x, ty) sol =
+  let sol' = type_subst_to_sol (x, ty) sol in
+  Map.add_exn sol' ~key:x ~data:ty
+
+let rec is_free x = function
+  | TyVar y -> (x <> y)
+  | TyStruct tys ->
+     List.for_all ~f:(is_free x) tys
+  | TyFun (tys, ty) ->
+     List.for_all ~f:(is_free x) (ty::tys)
+  | TyUnion (ty1, ty2) ->
+     is_free x ty1 && is_free x ty2
+  | TyConstraint (ty, c) ->
+     is_free x ty (* TODO: for constraint ? *)
+  | TyAny | TyNone | TyInteger | TyAtom | TyConstant _  -> true
+
+(* see TAPL https://dwango.slack.com/messages/CD453S78B/ *)
+let rec solve_eq sol ty1 ty2 =
   match (ty1, ty2) with
-  | (ty1, ty2) when Caml.Pervasives.(=) ty1 ty2 -> Ok sol
+  | (ty1, ty2) when ty1 = ty2 -> Ok sol
+  | (TyVar x, ty2) when is_free x ty2 ->
+     Ok (add (x, ty2) sol)
+  | (ty1, TyVar y) when is_free y ty1 ->
+     Ok (add (y, ty1) sol)
+  | (TyVar v, _) | (_, TyVar v) ->
+     Error (Failure (Printf.sprintf "not free variable: %s" v))
+  | (TyStruct tys1, TyStruct tys2) when List.length tys1 = List.length tys2 ->
+     let open Result in
+     List.zip_exn tys1 tys2
+     |> List.fold_left ~init:(Ok sol) ~f:(fun res (ty1,ty2) -> res >>= fun sol -> solve_eq sol ty1 ty2) 
+  | (TyStruct tys1, TyStruct tys2) ->
+     Error (Failure ("the tuple types are not different length"))
+  | (TyFun (tys1, ty1), TyFun (tys2, ty2)) when List.length tys1 = List.length tys2 ->
+     let open Result in
+     List.zip_exn (ty1::tys1) (ty2::tys2)
+     |> List.fold_left ~init:(Ok sol) ~f:(fun res (ty1,ty2) -> res >>= fun sol -> solve_eq sol ty1 ty2) 
+  | (TyFun (tys1, ty1), TyFun (tys2, ty2)) ->
+     Error (Failure ("the function types's arugment are not different length"))
+  | (TyUnion (ty11, ty12), TyUnion (ty21, ty22)) ->
+  (* TODO: equality of unions *)
+     Error (Failure ("not implemented: solve_eq with union types"))
+  | (TyConstraint (ty1, c1), TyConstraint (ty2, c2)) ->
+     (* TODO: equality with constraint *)     
+     Error (Failure ("not implemented: solve_eq with constraint"))
   | _ ->
-     Ok sol (*TODO : see TAPL https://dwango.slack.com/messages/CD453S78B/ *)
+     Error (Failure (Printf.sprintf "must not eq type: %s =? %s" (show_typ ty1) (show_typ ty2)))
+
 let solve_sub sol ty1 ty2 = Ok sol (*TODO*)
 
 let rec solve sol = function

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1,0 +1,25 @@
+open Base
+open Types
+
+type ty_var = string
+type sol = (ty_var, typ, String.comparator_witness) Map.t
+
+let solve_eq sol ty1 ty2 = Ok sol (*TODO : see TAPL https://dwango.slack.com/messages/CD453S78B/ *)
+let solve_sub sol ty1 ty2 = Ok sol (*TODO*)
+
+let rec solve sol = function
+  | Empty -> Ok sol
+  | Eq (ty1, ty2) ->
+     solve_eq sol ty1 ty2
+  | Subtype (ty1, ty2) ->
+     solve_sub sol ty1 ty2
+  | Conj cs ->
+     solve_conj sol cs
+  | Disj cs ->
+     Error (Failure "unimplemented : solving Disjunction of constraints")
+and solve_conj sol = function
+  | [] -> Ok sol
+  | c :: cs ->
+     let open Result in
+     solve sol c >>= fun sol' ->
+     solve_conj sol' cs

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1,5 +1,5 @@
 open Base
-open Types
+open Ast_intf
 
 type ty_var = string
 type sol = (ty_var, typ, String.comparator_witness) Map.t

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -26,6 +26,12 @@ let rec type_subst ((x : ty_var) , (ty1 : typ)): typ -> typ = function
 and type_subst_to_constraint (x, ty1) = function
   | _ ->
      failwith "not implemented "
+
+let solve_eq sol ty1 ty2 =
+  match (ty1, ty2) with
+  | (ty1, ty2) when Caml.Pervasives.(=) ty1 ty2 -> Ok sol
+  | _ ->
+     Ok sol (*TODO : see TAPL https://dwango.slack.com/messages/CD453S78B/ *)
 let solve_sub sol ty1 ty2 = Ok sol (*TODO*)
 
 let rec solve sol = function

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -4,7 +4,28 @@ open Ast_intf
 type ty_var = string
 type sol = (ty_var, typ, String.comparator_witness) Map.t
 
-let solve_eq sol ty1 ty2 = Ok sol (*TODO : see TAPL https://dwango.slack.com/messages/CD453S78B/ *)
+(* 型 type_subst (X, τ_1) τ_2 := [X ↦ τ_1]τ_2 *)
+let rec type_subst ((x : ty_var) , (ty1 : typ)): typ -> typ = function
+  | TyStruct tys ->
+     TyStruct(List.map ~f:(type_subst (x, ty1)) tys)
+  | TyFun (tys, ty) ->
+     TyFun (List.map ~f:(type_subst (x, ty1)) tys, type_subst (x, ty1) ty)
+  | TyUnion (ty_a, ty_b) ->
+     TyUnion(type_subst (x, ty1) ty_a, type_subst (x, ty1) ty_b)
+  | TyConstraint (ty, c) ->
+     TyConstraint(type_subst (x, ty1) ty, type_subst_to_constraint (x, ty1) c)
+  | TyAny -> TyAny
+  | TyNone -> TyNone
+  | TyInteger -> TyInteger
+  | TyAtom -> TyAtom
+  | TyConstant const -> TyConstant const
+  | TyVar (v:ty_var) ->
+     if
+       String.equal x v
+     then ty1 else (TyVar v)
+and type_subst_to_constraint (x, ty1) = function
+  | _ ->
+     failwith "not implemented "
 let solve_sub sol ty1 ty2 = Ok sol (*TODO*)
 
 let rec solve sol = function
@@ -16,7 +37,7 @@ let rec solve sol = function
   | Conj cs ->
      solve_conj sol cs
   | Disj cs ->
-     Error (Failure "unimplemented : solving Disjunction of constraints")
+     Error (Failure "not implemented : solving Disjunction of constraints")
 and solve_conj sol = function
   | [] -> Ok sol
   | c :: cs ->

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -4,10 +4,9 @@ module Map = Base.Map
 module String = Base.String
 module Result = Base.Result
 
-type ty_var = string
-type sol = (ty_var, typ, String.comparator_witness) Map.t
+type sol = typ Map.M(Type_variable).t
          
-let init : sol = Map.empty (module String)
+let init : sol = Map.empty (module Type_variable)
 
 (* type_subst (X, τ_1) τ_2 := [X ↦ τ_1]τ_2 *)
 let rec type_subst (x, ty1): typ -> typ = function
@@ -58,7 +57,7 @@ let rec solve_eq sol ty1 ty2 =
   | (ty1, TyVar y) when is_free y ty1 ->
      Ok (add (y, ty1) sol)
   | (TyVar v, _) | (_, TyVar v) ->
-     Error (Failure (Printf.sprintf "not free variable: %s" v))
+     Error (Failure (Printf.sprintf "not free variable: %s" (Type_variable.show v)))
   | (TyStruct tys1, TyStruct tys2) when List.length tys1 = List.length tys2 ->
      let open Result in
      List.zip_exn tys1 tys2

--- a/lib/type_variable.ml
+++ b/lib/type_variable.ml
@@ -5,6 +5,8 @@ type t = string
 
 type comparator_witness = Base.String.comparator_witness
 
+let comparator = Base.String.comparator
+
 let count = ref (-1)
 
 let create () =

--- a/lib/type_variable.mli
+++ b/lib/type_variable.mli
@@ -3,5 +3,6 @@ type t
 
 type comparator_witness
 
+val comparator : (t, comparator_witness) Base.Comparator.t
 val create : unit -> t
 val reset_count : unit -> unit


### PR DESCRIPTION
fix #13 
introduce the function:

```ocaml
val solve : sol -> constraint_ -> (sol, exn) Result.t
```

## example

```ocaml
open Ast_intf

let () =
  let x = "x" in
  let expr = (App (Abs ([x], (Var x)), [Val (Int 0)]))
  in
  match Derivation.derive Context.empty expr with
  | Ok (ty, c) ->
     Printf.printf "derivated: %s, %s\n" (Ast_intf.show_typ ty) (Ast_intf.show_constraint_ c);
     begin match Solver.solve Solver.init c with
     | Ok sol ->
        Printf.printf "solved:\n";
        Base.Map.iteri sol ~f:(fun ~key:v ~data:ty ->
                    Printf.printf "  solution: %s |-> %s\n" v (show_typ ty));
     | Error exn ->
        raise exn
     end
  | Error msg ->
     failwith msg
```
```
derivated: (Ast_intf.TyVar "v04"), (Ast_intf.Conj
   [(Ast_intf.Eq (
       (Ast_intf.TyFun ([(Ast_intf.TyVar "v01")],
          (Ast_intf.TyConstraint ((Ast_intf.TyVar "v01"), Ast_intf.Empty)))),
       (Ast_intf.TyFun ([(Ast_intf.TyVar "v02")], (Ast_intf.TyVar "v03")))));
     (Ast_intf.Subtype ((Ast_intf.TyVar "v04"), (Ast_intf.TyVar "v03")));
     (Ast_intf.Subtype ((Ast_intf.TyConstant (Ast_intf.Int 0)),
        (Ast_intf.TyVar "v02")));
     Ast_intf.Empty; Ast_intf.Empty])
solved:
  solution: v01 |-> (Ast_intf.TyVar "v02")
  solution: v03 |-> (Ast_intf.TyConstraint ((Ast_intf.TyVar "v02"), Ast_intf.Empty))
```