### PR TITLE
read beamfile and show derivated type

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,4 +1,6 @@
 open Obeam
+open Base
+open Result
 
 let extract_debug_info_buf layout =
   let {
@@ -24,31 +26,42 @@ let beam_to_etf beam_buf = match Chunk.parse_layout beam_buf with
        match External_term_format.parse debug_info_buf with
        | Ok (expr, _) ->
           Ok expr
-       | Error (msg, rest) ->
-          Error (msg, rest)
+       | Error (msg, _rest) ->
+          Error (Failure msg)
      end
-  | Error (msg, rest) ->
-     Error (msg, rest)
+  | Error (msg, _rest) ->
+     Error (Failure msg)
+
+let show_usage () =
+  Printf.sprintf "Usage: %s <beam_filename>" Sys.argv.(0)
+
+let read_file beam_filename =
+  try_with (fun () -> Bitstring.bitstring_of_file beam_filename) >>= fun beam ->
+  beam_to_etf beam >>= fun etf ->
+  let sf = Simple_term_format.of_etf etf in
+  Ok (Abstract_format.of_sf sf)
+
+let read_input () =
+  match Sys.argv with
+  | [|_; beam_filename|] ->
+     read_file beam_filename
+  | _ ->
+     Error (Failure (show_usage()))
+
+let main =
+  read_input () >>= fun code ->
+  Printf.sprintf "code: %s" (Abstract_format.show code) |> Caml.print_endline;
+  From_erlang.code_to_expr code >>= fun expr ->
+  Printf.sprintf "expr: %s" (Ast_intf.show_expr expr) |> Caml.print_endline;
+  (Derivation.derive Context.empty expr |> map_error ~f:(fun msg -> Failure msg)) >>= fun (ty, c) ->
+  Printf.sprintf "type: %s" (Ast_intf.show_typ ty) |> Caml.print_endline;
+  Printf.sprintf "constraint: %s" (Ast_intf.show_constraint_ c) |> Caml.print_endline;
+  Ok ()
 
 let () =
-  let beam_filename =
-    match Sys.argv with
-    | [|_; n|] -> n
-    | _ -> failwith (Printf.sprintf "format: %s <beam_filename>" Sys.argv.(0))
-  in
-
-  let beam_buf = Bitstring.bitstring_of_file beam_filename in
-  match beam_to_etf beam_buf with
-  | Ok etf ->
-     let sf = Simple_term_format.of_etf etf in
-     let code = Abstract_format.of_sf sf in
-     Printf.printf "code: %s" (Abstract_format.show code);
-     begin match From_erlang.code_to_expr code with
-     | Ok m ->
-        Printf.printf "code: %s" (Ast_intf.show_expr m)
-     | Error exn ->
-        raise exn
-     end
-  | Error (msg, rest) ->
-     Printf.printf "Failed to parse chunk: %s\n" msg;
-     Bitstring.hexdump_bitstring stdout rest
+  match main with
+  | Ok () -> ()
+  | Error (Failure msg) ->
+     Caml.prerr_endline msg
+  | Error exn ->
+     raise exn

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,7 @@
 open Obeam
 open Base
 open Result
+open Common
 
 let extract_debug_info_buf layout =
   let {
@@ -50,12 +51,12 @@ let read_input () =
 
 let main =
   read_input () >>= fun code ->
-  Printf.sprintf "code: %s" (Abstract_format.show code) |> Caml.print_endline;
+  Caml.print_endline (!%"code: %s" (Abstract_format.show code));
   From_erlang.code_to_expr code >>= fun expr ->
-  Printf.sprintf "expr: %s" (Ast_intf.show_expr expr) |> Caml.print_endline;
+  Caml.print_endline (!%"expr: %s" (Ast_intf.string_of_expr expr));
   (Derivation.derive Context.empty expr |> map_error ~f:(fun msg -> Failure msg)) >>= fun (ty, c) ->
-  Printf.sprintf "type: %s" (Ast_intf.show_typ ty) |> Caml.print_endline;
-  Printf.sprintf "constraint: %s" (Ast_intf.show_constraint_ c) |> Caml.print_endline;
+  Caml.print_endline (!%"type: %s" (Ast_intf.string_of_typ ty));
+  Caml.print_endline (!%"constraint:\n%s" (Ast_intf.string_of_constraint c));
   Ok ()
 
 let () =

--- a/lib/ast_intf.ml
+++ b/lib/ast_intf.ml
@@ -30,7 +30,7 @@ let string_of_expr expr =
   [%sexp_of: expr] expr |> Sexplib.Sexp.to_string_hum ~indent:2
 
 type typ =
-    | TyVar of string
+    | TyVar of Type_variable.t
     | TyStruct of typ list
     | TyFun of typ list * typ
     | TyUnion of typ * typ

--- a/lib/ast_intf.ml
+++ b/lib/ast_intf.ml
@@ -26,6 +26,9 @@ and pattern =
     | PatStruct of string list * expr
 [@@deriving show, sexp_of]
 
+let string_of_expr expr =
+  [%sexp_of: expr] expr |> Sexplib.Sexp.to_string_hum ~indent:2
+
 type typ =
     | TyVar of string
     | TyStruct of typ list
@@ -45,6 +48,11 @@ and constraint_ =
     | Disj of constraint_ list
     | Empty
 [@@deriving show, sexp_of]
+
+let string_of_typ typ =
+  [%sexp_of: typ] typ |> Sexplib.Sexp.to_string_hum ~indent:2
+let string_of_constraint c =
+  [%sexp_of: constraint_] c |> Sexplib.Sexp.to_string_hum ~indent:2
 
 type spec_fun = typ list * typ
 [@@deriving show, sexp_of]

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -1,2 +1,6 @@
 open Base
 let result_map_m rs ~f:f = Result.all (List.map rs ~f:f)
+
+let (!%) = Printf.sprintf
+let (<<<) = Fn.compose
+let (>>>) f g = g <<< f

--- a/lib/common.mli
+++ b/lib/common.mli
@@ -1,3 +1,6 @@
 open Base
-val result_map_m : 'a list -> f:('a -> ('b, 'c) Result.t) -> ('b list, 'c) Result.t
 
+val result_map_m : 'a list -> f:('a -> ('b, 'c) Result.t) -> ('b list, 'c) Result.t
+val (!%) : ('a, unit, string) format -> 'a
+val (<<<) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
+val (>>>) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -3,14 +3,7 @@ open Common
 open Ast_intf
 open Result
 
-let tyvar_count = ref 0
-
-let new_tyvar () =
-  Int.incr tyvar_count;
-  TyVar (Printf.sprintf "%s%02d" "v" !tyvar_count)
-
-let reset_tyvar_count () =
-  tyvar_count := 0
+let new_tyvar () = TyVar (Type_variable.create())
 
 let rec derive context = function
   | Val c ->

--- a/lib/derivation.mli
+++ b/lib/derivation.mli
@@ -1,5 +1,3 @@
 open Base
 
-val reset_tyvar_count : unit -> unit
-
 val derive : Context.t -> Ast_intf.expr -> (Ast_intf.typ * Ast_intf.constraint_, string) Result.t

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name fialyzer)
  (public_name fialyzer)
  (wrapped false)
- (libraries obeam base)
+ (libraries obeam base sexplib)
  (preprocess (pps ppx_sexp_conv ppx_deriving.std)))
 
 (env

--- a/lib/type_variable.ml
+++ b/lib/type_variable.ml
@@ -15,4 +15,4 @@ let create () =
     Printf.sprintf "%s%02d" "v" !count
 
 let reset_count () =
-  count := 0
+  count := -1

--- a/lib/type_variable.ml
+++ b/lib/type_variable.ml
@@ -1,0 +1,18 @@
+let sexp_of_string = Base.sexp_of_string
+
+type t = string
+[@@deriving show, sexp_of]
+
+type comparator_witness = Base.String.comparator_witness
+
+let count = ref (-1)
+
+let create () =
+  incr count;
+  if !count <= (int_of_char 'z' - int_of_char 'a') then
+    Printf.sprintf "%c" (char_of_int (int_of_char 'a' + !count))
+  else
+    Printf.sprintf "%s%02d" "v" !count
+
+let reset_count () =
+  count := 0

--- a/lib/type_variable.mli
+++ b/lib/type_variable.mli
@@ -1,0 +1,7 @@
+type t
+[@@deriving show, sexp_of]
+
+type comparator_witness
+
+val create : unit -> t
+val reset_count : unit -> unit

--- a/test/test_derivation.ml
+++ b/test/test_derivation.ml
@@ -4,7 +4,7 @@ open Derivation
 
 let%expect_test "derivation" =
   let print context term =
-    reset_tyvar_count ();
+    Type_variable.reset_count ();
     Expect_test_helpers_kernel.print_s
       [%sexp ((derive context term) : (typ * constraint_, string) Result.t)] in
 
@@ -20,34 +20,33 @@ let%expect_test "derivation" =
   print Context.empty (Abs (["x"], Var "x"));
   [%expect {|
     (Ok (
-      (TyVar v02)
-      (Eq (TyVar v02) (TyConstraint (TyFun ((TyVar v01)) (TyVar v01)) Empty)))) |}];
+      (TyVar b) (Eq (TyVar b) (TyConstraint (TyFun ((TyVar a)) (TyVar a)) Empty)))) |}];
 
   print Context.empty (Abs (["x"; "y"; "z"], Var "x"));
   [%expect {|
     (Ok (
-      (TyVar v04)
+      (TyVar d)
       (Eq
-        (TyVar v04)
+        (TyVar d)
         (TyConstraint
           (TyFun
-            ((TyVar v01)
-             (TyVar v02)
-             (TyVar v03))
-            (TyVar v01))
+            ((TyVar a)
+             (TyVar b)
+             (TyVar c))
+            (TyVar a))
           Empty)))) |}];
 
   print Context.empty (App (Abs (["x"], Var "x"), [Val (Int 42)]));
   [%expect {|
     (Ok (
-      (TyVar v05)
+      (TyVar e)
       (Conj (
-        (Eq (TyVar v02) (TyFun ((TyVar v03)) (TyVar v04)))
+        (Eq (TyVar b) (TyFun ((TyVar c)) (TyVar d)))
         (Subtype
-          (TyVar v05)
-          (TyVar v04))
-        (Subtype (TyConstant (Int 42)) (TyVar v03))
-        (Eq (TyVar v02) (TyConstraint (TyFun ((TyVar v01)) (TyVar v01)) Empty))
+          (TyVar e)
+          (TyVar d))
+        (Subtype (TyConstant (Int 42)) (TyVar c))
+        (Eq (TyVar b) (TyConstraint (TyFun ((TyVar a)) (TyVar a)) Empty))
         Empty)))) |}];
 
   (* TODO: implement derivation of application expression with multiple arguments
@@ -62,7 +61,7 @@ let%expect_test "derivation" =
       (Conj       (Empty Empty)))) |}];
 
   print Context.empty (Letrec ([("x", Val (Int 42))], Var "x"));
-  [%expect {| (Ok ((TyVar v01) (Conj (Empty (Eq (TyVar v01) (TyConstant (Int 42))) Empty)))) |}];
+  [%expect {| (Ok ((TyVar a) (Conj (Empty (Eq (TyVar a) (TyConstant (Int 42))) Empty)))) |}];
 
   print
     Context.empty
@@ -73,39 +72,39 @@ let%expect_test "derivation" =
       ], App (Var "f", [Val (Int 42)])));
   [%expect {|
     (Ok (
-      (TyVar v15)
+      (TyVar o)
       (Conj (
         (Conj (
-          (Eq (TyVar v01) (TyFun ((TyVar v13)) (TyVar v14)))
+          (Eq (TyVar a) (TyFun ((TyVar m)) (TyVar n)))
           (Subtype
-            (TyVar v15)
-            (TyVar v14))
-          (Subtype (TyConstant (Int 42)) (TyVar v13))
+            (TyVar o)
+            (TyVar n))
+          (Subtype (TyConstant (Int 42)) (TyVar m))
           Empty
           Empty))
         (Eq
-          (TyVar v01)
-          (TyVar v07))
+          (TyVar a)
+          (TyVar g))
         (Eq
-          (TyVar v07)
+          (TyVar g)
           (TyConstraint
-            (TyFun ((TyVar v03)) (TyVar v06))
+            (TyFun ((TyVar c)) (TyVar f))
             (Conj (
-              (Eq (TyVar v02) (TyFun ((TyVar v04)) (TyVar v05)))
-              (Subtype (TyVar v06) (TyVar v05))
-              (Subtype (TyVar v03) (TyVar v04))
+              (Eq (TyVar b) (TyFun ((TyVar d)) (TyVar e)))
+              (Subtype (TyVar f) (TyVar e))
+              (Subtype (TyVar c) (TyVar d))
               Empty
               Empty))))
         (Eq
-          (TyVar v02)
-          (TyVar v12))
+          (TyVar b)
+          (TyVar l))
         (Eq
-          (TyVar v12)
+          (TyVar l)
           (TyConstraint
-            (TyFun ((TyVar v08)) (TyVar v11))
+            (TyFun ((TyVar h)) (TyVar k))
             (Conj (
-              (Eq (TyVar v01) (TyFun ((TyVar v09)) (TyVar v10)))
-              (Subtype (TyVar v11) (TyVar v10))
-              (Subtype (TyVar v08) (TyVar v09))
+              (Eq (TyVar a) (TyFun ((TyVar i)) (TyVar j)))
+              (Subtype (TyVar k) (TyVar j))
+              (Subtype (TyVar h) (TyVar i))
               Empty
               Empty)))))))) |}];


### PR DESCRIPTION
Show derivated types:

```console
$ _build/default/bin/main.exe samples/test01.beam
```
```ocaml
code: (Abstract_format.AbstractCode
   (Abstract_format.ModDecl
      [(Abstract_format.AttrFile (1, "obeam/test/test01.erl", 1));
        (Abstract_format.AttrMod (1, "test01"));
        (Abstract_format.AttrExport (3, [("g", 0); ("h", 1)]));
        (Abstract_format.DeclFun (5, "f", 0,
           [(Abstract_format.ClsFun (5, [], None,
               (Abstract_format.ExprBody
                  [(Abstract_format.ExprLit
                      (Abstract_format.LitInteger (6, 0)))
                    ])
               ))
             ]
           ));
        (Abstract_format.DeclFun (8, "g", 0,
           [(Abstract_format.ClsFun (8, [], None,
               (Abstract_format.ExprBody
                  [(Abstract_format.ExprLit
                      (Abstract_format.LitInteger (9, 10)))
                    ])
               ))
             ]
           ));
        (Abstract_format.SpecFun (11, None, "h", 1,
           [(Abstract_format.TyFun (11,
               (Abstract_format.TyProduct (11,
                  [(Abstract_format.TyPredef (11, "integer", []))])),
               (Abstract_format.TyPredef (11, "string", []))))
             ]
           ));
        (Abstract_format.DeclFun (12, "h", 1,
           [(Abstract_format.ClsFun (12, [(Abstract_format.PatUniversal 12)],
               None,
               (Abstract_format.ExprBody
                  [(Abstract_format.ExprLit
                      (Abstract_format.LitString (13, "abcdefg")))
                    ])
               ))
             ]
           ));
        Abstract_format.FormEof]))
expr: (Letrec
  ((f (Abs () (Val (Int 0)))) (g (Abs () (Val (Int 10))))
    (h (Abs (_) (Val (String abcdefg)))))
  (Struct ((Var f) (Var g) (Var h))))
type: (TyStruct ((TyVar a) (TyVar b) (TyVar c)))
constraint:
(Conj
  ((Conj (Empty Empty Empty)) (Eq (TyVar c) (TyVar g))
    (Eq (TyVar g)
      (TyConstraint (TyFun ((TyVar f)) (TyConstant (String abcdefg))) Empty))
    (Eq (TyVar b) (TyVar e))
    (Eq (TyVar e) (TyConstraint (TyFun () (TyConstant (Int 10))) Empty))
    (Eq (TyVar a) (TyVar d))
    (Eq (TyVar d) (TyConstraint (TyFun () (TyConstant (Int 0))) Empty))))
```

```console
 $ _build/default/bin/main.exe samples/test02.beam 
```
```ocaml
code: (Abstract_format.AbstractCode
   (Abstract_format.ModDecl
      [(Abstract_format.AttrFile (1, "obeam/test/test02.erl", 1));
        (Abstract_format.AttrMod (1, "test02"));
        (Abstract_format.SpecFun (3, None, "i", 1,
           [(Abstract_format.TyContFun (3,
               (Abstract_format.TyPredef (3, "fun",
                  [(Abstract_format.TyProduct (3,
                      [(Abstract_format.TyVar (3, "A"))]));
                    (Abstract_format.TyPredef (3, "integer", []))]
                  )),
               (Abstract_format.TyCont
                  [(Abstract_format.TyContRel (3,
                      (Abstract_format.TyContIsSubType 3),
                      (Abstract_format.TyVar (3, "A")),
                      (Abstract_format.TyPredef (3, "integer", []))))
                    ])
               ))
             ]
           ));
        (Abstract_format.DeclFun (4, "i", 1,
           [(Abstract_format.ClsFun (4, [(Abstract_format.PatVar (4, "N"))],
               None,
               (Abstract_format.ExprBody [(Abstract_format.ExprVar (4, "N"))])
               ))
             ]
           ));
        (Abstract_format.SpecFun (6, None, "j", 1,
           [(Abstract_format.TyContFun (6,
               (Abstract_format.TyPredef (6, "fun",
                  [(Abstract_format.TyProduct (6,
                      [(Abstract_format.TyVar (6, "A"))]));
                    (Abstract_format.TyVar (6, "B"))]
                  )),
               (Abstract_format.TyCont
                  [(Abstract_format.TyContRel (6,
                      (Abstract_format.TyContIsSubType 6),
                      (Abstract_format.TyVar (6, "A")),
                      (Abstract_format.TyPredef (6, "integer", []))));
                    (Abstract_format.TyContRel (7,
                       (Abstract_format.TyContIsSubType 7),
                       (Abstract_format.TyVar (7, "B")),
                       (Abstract_format.TyPredef (7, "integer", []))))
                    ])
               ))
             ]
           ));
        (Abstract_format.DeclFun (8, "j", 1,
           [(Abstract_format.ClsFun (8, [(Abstract_format.PatVar (8, "N"))],
               None,
               (Abstract_format.ExprBody
                  [(Abstract_format.ExprBinOp (9, "*",
                      (Abstract_format.ExprVar (9, "N")),
                      (Abstract_format.ExprVar (9, "N"))))
                    ])
               ))
             ]
           ));
        Abstract_format.FormEof]))
expr: (Letrec ((i (Abs (N) (Var N))) (j (Abs (N) (App (Var *) ((Var N) (Var N))))))
  (Struct ((Var i) (Var j))))
unsupported type: (Ast_intf.App ((Ast_intf.Var "*"), [(Ast_intf.Var "N"); (Ast_intf.Var "N")]))
```

```console
 $ _build/default/bin/main.exe samples/test03.beam 
```
```ocaml
code: (Abstract_format.AbstractCode
   (Abstract_format.ModDecl
      [(Abstract_format.AttrFile (1, "obeam/test/test03.erl", 1));
        (Abstract_format.AttrMod (1, "test03"));
        (Abstract_format.DeclFun (3, "f", 1,
           [(Abstract_format.ClsFun (3, [(Abstract_format.PatVar (3, "N"))],
               (Some (Abstract_format.GuardSeq
                        [(Abstract_format.Guard
                            [(Abstract_format.GuardTestCall (3,
                                (Abstract_format.LitAtom (3, "is_integer")),
                                [(Abstract_format.GuardTestVar (3, "N"))]))
                              ])
                          ])),
               (Abstract_format.ExprBody
                  [(Abstract_format.ExprLit
                      (Abstract_format.LitInteger (4, 0)))
                    ])
               ));
             (Abstract_format.ClsFun (5, [(Abstract_format.PatUniversal 5)],
                None,
                (Abstract_format.ExprBody
                   [(Abstract_format.ExprLit
                       (Abstract_format.LitInteger (6, 2)))
                     ])
                ))
             ]
           ));
        Abstract_format.FormEof]))
expr: (Letrec ((f (Abs (N) (Val (Int 0))))) (Struct ((Var f))))
type: (TyStruct ((TyVar a)))
constraint:
(Conj
  ((Conj (Empty)) (Eq (TyVar a) (TyVar c))
    (Eq (TyVar c)
      (TyConstraint (TyFun ((TyVar b)) (TyConstant (Int 0))) Empty))))
```