### PR TITLE
Fix the definition of type pattern

### DIFF
--- a/lib/ast_intf.ml
+++ b/lib/ast_intf.ml
@@ -21,9 +21,10 @@ type expr =
     | Letrec of (string * expr) list * expr
     | Case of expr * (pattern * expr) list
 [@@deriving show, sexp_of]
-and pattern =
-    | PatVar of string * expr
-    | PatStruct of string list * expr
+and pattern = pattern_ * expr
+and pattern_ =
+    | PatVar of string
+    | PatStruct of pattern_ list
 [@@deriving show, sexp_of]
 
 let string_of_expr expr =

--- a/lib/ast_intf.ml
+++ b/lib/ast_intf.ml
@@ -21,10 +21,10 @@ type expr =
     | Letrec of (string * expr) list * expr
     | Case of expr * (pattern * expr) list
 [@@deriving show, sexp_of]
-and pattern = pattern_ * expr
-and pattern_ =
+and pattern = pattern' * expr
+and pattern' =
     | PatVar of string
-    | PatStruct of pattern_ list
+    | PatStruct of pattern' list
 [@@deriving show, sexp_of]
 
 let string_of_expr expr =

--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -23,8 +23,8 @@ let rec expr_of_erlang_expr = function
      expr_of_exprs (List.map ~f:expr_of_erlang_expr erlangs)
   | ExprCase (_line_t, e, clauses) ->
     let cs = clauses |> List.map ~f:(function 
-    | F.ClsCase (_, F.PatVar (_, v), _, e) -> ((PatVar (v), Val (Atom("true"))), expr_of_erlang_expr e)
-    | F.ClsCase (_, F.PatUniversal _, _, e) -> ((PatVar ("_"), Val (Atom("true"))), expr_of_erlang_expr e)
+    | F.ClsCase (_, F.PatVar (_, v), _, e) -> ((PatVar v, Val (Atom "true")), expr_of_erlang_expr e)
+    | F.ClsCase (_, F.PatUniversal _, _, e) -> ((PatVar "_", Val (Atom "true")), expr_of_erlang_expr e)
     | F.ClsCase (_, _, _, _) | F.ClsFun (_, _, _, _) -> failwith "not implemented"
     ) in
     Case (expr_of_erlang_expr e, cs)

--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -23,8 +23,8 @@ let rec expr_of_erlang_expr = function
      expr_of_exprs (List.map ~f:expr_of_erlang_expr erlangs)
   | ExprCase (_line_t, e, clauses) ->
     let cs = clauses |> List.map ~f:(function 
-    | F.ClsCase (_, F.PatVar (_, v), _, e) -> (PatVar (v, Val(Atom("true"))), expr_of_erlang_expr e)
-    | F.ClsCase (_, F.PatUniversal _, _, e) -> (PatVar ("_", Val(Atom("true"))), expr_of_erlang_expr e)
+    | F.ClsCase (_, F.PatVar (_, v), _, e) -> ((PatVar (v), Val (Atom("true"))), expr_of_erlang_expr e)
+    | F.ClsCase (_, F.PatUniversal _, _, e) -> ((PatVar ("_"), Val (Atom("true"))), expr_of_erlang_expr e)
     | F.ClsCase (_, _, _, _) | F.ClsFun (_, _, _, _) -> failwith "not implemented"
     ) in
     Case (expr_of_erlang_expr e, cs)


### PR DESCRIPTION
* Refer the definition of pattern in the paper "Practical Type Inference Based on Success Typings":

```
p ::= p′ when g
p′ ::= x | c(p′1, . . . , p′n)
```