### PR TITLE
Introduce MFA to expr

### DIFF
--- a/lib/ast_intf.ml
+++ b/lib/ast_intf.ml
@@ -27,6 +27,7 @@ type expr =
     | Let of string * expr * expr
     | Letrec of (string * expr) list * expr
     | Case of expr * (pattern * expr) list
+    | MFA of expr * expr * expr
 [@@deriving show, sexp_of]
 and pattern = pattern' * expr
 and pattern' =

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1,10 +1,17 @@
 open Base
 open Ast_intf
 
-module TypeVar = String
+module Key = struct
+  module T = struct
+    type t = Var of String.t | MFA of String.t * String.t * Int.t
+    [@@deriving sexp_of, ord]
+  end
+  include T
+  include Comparator.Make(T)
+end
 
-type t = typ Map.M(TypeVar).t
+type t = typ Map.M(Key).t
 
-let empty : t = Map.empty (module String)
+let empty : t = Map.empty (module Key)
 let find = Map.find
 let add key data = Map.add_exn ~key ~data

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -1,10 +1,13 @@
 open Base
 open Ast_intf
 
-module TypeVar = String
+module Key : sig
+  type t = Var of String.t | MFA of String.t * String.t * Int.t
+  [@@deriving sexp_of, ord]
+end
 
 type t
 
 val empty : t
-val find : t -> TypeVar.t -> typ option
-val add : TypeVar.t -> typ -> t -> t
+val find : t -> Key.t -> typ option
+val add : Key.t -> typ -> t -> t

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -93,7 +93,7 @@ let rec derive context = function
         Subtype (ty_m, TyAtom);
         Subtype (ty_f, TyAtom);
         Subtype (ty_a, TyInteger);
-        Subtype (tyvar_mfa, TyAny)] (* cannot be TyFun (.., ..) because arity is unknown *)
+        Subtype (tyvar_mfa, TyAny)] (* cannot be TyFun (.., ..) because the arity is unknown. give up *)
      in
      Ok (tyvar_mfa, Conj cs)
   | other ->

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -75,12 +75,12 @@ let rec derive context = function
      derive added_context e >>= fun (ty, c) ->
      Ok (ty, Conj (c :: constraints))
   | MFA (Val (Atom m), Val (Atom f), Val (Int a)) ->
-     (* TODO: find MFA from context *)
+     (* find MFA from context *)
      begin match Context.find context (Context.Key.MFA (m, f, a)) with
      | Some ty ->
         Ok (ty, Empty)
      | None ->
-        Error ("unknown type variable: " ^ f)
+        Error (Printf.sprintf "unknown MFA: %s:%s/%d" m f a)
      end
   | MFA (m, f, a) ->
      (* few info to find MFA *)

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -9,7 +9,7 @@ let rec derive context = function
   | Val c ->
      Ok (TyConstant c, Empty)
   | Var v ->
-     begin match Context.find context v with
+     begin match Context.find context (Context.Key.Var v) with
      | Some ty ->
         Ok (ty, Empty)
      | None ->
@@ -48,7 +48,7 @@ let rec derive context = function
      let new_tyvars = List.map ~f:(fun v -> (v, (new_tyvar ()))) vs in
      let added_context =
        List.fold_left
-         ~f:(fun context (v, tyvar) -> Context.add v tyvar context)
+         ~f:(fun context (v, tyvar) -> Context.add (Context.Key.Var v) tyvar context)
          ~init:context
          new_tyvars in
      derive added_context e >>= fun (ty_e, c) ->
@@ -56,13 +56,13 @@ let rec derive context = function
      Ok (tyvar, Eq (tyvar, TyConstraint (TyFun (List.map ~f:snd new_tyvars, ty_e), c)))
   | Let (v, e1, e2) ->
      derive context e1 >>= fun (ty_e1, c1) ->
-     derive (Context.add v ty_e1 context) e2 >>= fun (ty_e2, c2) ->
+     derive (Context.add (Context.Key.Var v) ty_e1 context) e2 >>= fun (ty_e2, c2) ->
      Ok (ty_e2, Conj [c1; c2])
   | Letrec (lets , e) ->
      let new_tyvars = List.map ~f:(fun (v, f) -> (v, f, (new_tyvar ()))) lets in
      let added_context =
        List.fold_left
-         ~f:(fun context (v, _, tyvar) -> Context.add v tyvar context)
+         ~f:(fun context (v, _, tyvar) -> Context.add (Context.Key.Var v) tyvar context)
          ~init:context
          new_tyvars in
      let constraints_result =
@@ -76,7 +76,7 @@ let rec derive context = function
      Ok (ty, Conj (c :: constraints))
   | MFA (Val (Atom m), Val (Atom f), Val (Int a)) ->
      (* TODO: find MFA from context *)
-     begin match Context.find context f with
+     begin match Context.find context (Context.Key.MFA (m, f, a)) with
      | Some ty ->
         Ok (ty, Empty)
      | None ->

--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -31,9 +31,9 @@ let rec expr_of_erlang_expr = function
     Case (expr_of_erlang_expr e, cs)
   | ExprLocalCall (_line_t, f, args) ->
      App (expr_of_erlang_expr f, List.map ~f:expr_of_erlang_expr args)
-  | ExprRemoteCall (_line_t, _line_m, _m, f, args) ->
-     (* TODO: support full qualified call *)
-     App (expr_of_erlang_expr f, List.map ~f:expr_of_erlang_expr args)
+  | ExprRemoteCall (_line_t, _line_m, m, f, args) ->
+     let mfa = MFA (expr_of_erlang_expr m, expr_of_erlang_expr f, Val (Int (List.length args))) in
+     App (mfa, List.map ~f:expr_of_erlang_expr args)
   | ExprBinOp (_line_t, op, e1, e2) ->
      App(Var op, List.map ~f:expr_of_erlang_expr [e1; e2])
   | ExprVar (_line_t, v) -> Var v


### PR DESCRIPTION
I have introduced MFA into Ast_intf.expr for https://github.com/dwango/fialyzer/pull/64#discussion_r237022675.

This change breaks original mini-Erlang which introduced by success typing's paper, but changes like this will be required for adopting full Erlang codes.
