### PR TITLE
simplify type signature

### DIFF
--- a/lib/ast_intf.ml
+++ b/lib/ast_intf.ml
@@ -11,15 +11,12 @@ module Z = struct
 end
 
 type constant =
-    | Int of int
-    | BigInt of Z.t
-    | Float of float
+    | Number of int
     | Atom of string
-    | String of string
 [@@deriving show, sexp_of]
 
 type expr =
-    | Val of constant
+    | Constant of constant
     | Var of string
     | Tuple of expr list
     | App of expr * expr list
@@ -45,10 +42,10 @@ type typ =
     | TyUnion of typ * typ
     | TyConstraint of typ * constraint_
     | TyAny
-    | TyNone
-    | TyInteger
+    | TyBottom
+    | TyNumber
     | TyAtom
-    | TyConstant of constant
+    | TySingleton of constant
 [@@deriving show, sexp_of]
 and constraint_ =
     | Eq of typ * typ

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -6,8 +6,8 @@ open Result
 let new_tyvar () = TyVar (Type_variable.create())
 
 let rec derive context = function
-  | Val c ->
-     Ok (TyConstant c, Empty)
+  | Constant c ->
+     Ok (TySingleton c, Empty)
   | Var v ->
      begin match Context.find context (Context.Key.Var v) with
      | Some ty ->
@@ -74,7 +74,7 @@ let rec derive context = function
      constraints_result >>= fun constraints ->
      derive added_context e >>= fun (ty, c) ->
      Ok (ty, Conj (c :: constraints))
-  | MFA (Val (Atom m), Val (Atom f), Val (Int a)) ->
+  | MFA (Constant (Atom m), Constant (Atom f), Constant (Number a)) ->
      (* find MFA from context *)
      begin match Context.find context (Context.Key.MFA (m, f, a)) with
      | Some ty ->
@@ -92,7 +92,7 @@ let rec derive context = function
        [c_m; c_f; c_a;
         Subtype (ty_m, TyAtom);
         Subtype (ty_f, TyAtom);
-        Subtype (ty_a, TyInteger);
+        Subtype (ty_a, TyNumber);
         Subtype (tyvar_mfa, TyAny)] (* cannot be TyFun (.., ..) because the arity is unknown. give up *)
      in
      Ok (tyvar_mfa, Conj cs)

--- a/test/blackbox-test/test-cases/basic.expected
+++ b/test/blackbox-test/test-cases/basic.expected
@@ -37,43 +37,43 @@ code: (Abstract_format.AbstractCode
            ));
         Abstract_format.FormEof]))
 expr: (Letrec
-  ((ok (Abs () (Val (Atom ok)))) (id (Abs (A) (Var A)))
-    (ok2 (Abs () (App (Val (Atom id)) ((App (Val (Atom ok)) ()))))))
+  ((ok (Abs () (Constant (Atom ok)))) (id (Abs (A) (Var A)))
+    (ok2 (Abs () (App (Constant (Atom id)) ((App (Constant (Atom ok)) ()))))))
   (Tuple ((Var ok) (Var id) (Var ok2))))
 type: (TyTuple ((TyVar a) (TyVar b) (TyVar c)))
 constraint:
 (Conj
   ((Conj (Empty Empty Empty)) (Eq (TyVar a) (TyVar d))
-    (Eq (TyVar d) (TyConstraint (TyFun () (TyConstant (Atom ok))) Empty))
+    (Eq (TyVar d) (TyConstraint (TyFun () (TySingleton (Atom ok))) Empty))
     (Eq (TyVar b) (TyVar f))
     (Eq (TyVar f) (TyConstraint (TyFun ((TyVar e)) (TyVar e)) Empty))
     (Eq (TyVar c) (TyVar l))
     (Eq (TyVar l)
       (TyConstraint (TyFun () (TyVar k))
         (Conj
-          ((Eq (TyConstant (Atom id)) (TyFun ((TyVar i)) (TyVar j)))
+          ((Eq (TySingleton (Atom id)) (TyFun ((TyVar i)) (TyVar j)))
             (Subtype (TyVar k) (TyVar j)) Empty (Subtype (TyVar h) (TyVar i))
             (Conj
-              ((Eq (TyConstant (Atom ok)) (TyFun () (TyVar g)))
+              ((Eq (TySingleton (Atom ok)) (TyFun () (TyVar g)))
                 (Subtype (TyVar h) (TyVar g)) Empty))))))))
 solution:
-((a (TyConstraint (TyFun () (TyConstant (Atom ok))) Empty))
+((a (TyConstraint (TyFun () (TySingleton (Atom ok))) Empty))
   (b (TyConstraint (TyFun ((TyVar e)) (TyVar e)) Empty))
   (c
     (TyConstraint (TyFun () (TyVar k))
       (Conj
-        ((Eq (TyConstant (Atom id)) (TyFun ((TyVar i)) (TyVar j)))
+        ((Eq (TySingleton (Atom id)) (TyFun ((TyVar i)) (TyVar j)))
           (Subtype (TyVar k) (TyVar j)) Empty (Subtype (TyVar h) (TyVar i))
           (Conj
-            ((Eq (TyConstant (Atom ok)) (TyFun () (TyVar g)))
+            ((Eq (TySingleton (Atom ok)) (TyFun () (TyVar g)))
               (Subtype (TyVar h) (TyVar g)) Empty))))))
-  (d (TyConstraint (TyFun () (TyConstant (Atom ok))) Empty))
+  (d (TyConstraint (TyFun () (TySingleton (Atom ok))) Empty))
   (f (TyConstraint (TyFun ((TyVar e)) (TyVar e)) Empty))
   (l
     (TyConstraint (TyFun () (TyVar k))
       (Conj
-        ((Eq (TyConstant (Atom id)) (TyFun ((TyVar i)) (TyVar j)))
+        ((Eq (TySingleton (Atom id)) (TyFun ((TyVar i)) (TyVar j)))
           (Subtype (TyVar k) (TyVar j)) Empty (Subtype (TyVar h) (TyVar i))
           (Conj
-            ((Eq (TyConstant (Atom ok)) (TyFun () (TyVar g)))
+            ((Eq (TySingleton (Atom ok)) (TyFun () (TyVar g)))
               (Subtype (TyVar h) (TyVar g)) Empty)))))))


### PR DESCRIPTION
changes are:

- make constants a only single variant `Number`
- remove string constant
- rename : `TyConstant` → `TySingleton`
- rename : `TyNone` -> `TyBottom`
