### PR TITLE
[For debug] etf to string for human

### DIFF
--- a/lib/etf_util.ml
+++ b/lib/etf_util.ml
@@ -39,18 +39,18 @@ let sexp_of_etf etf = sexp_of_string (show_etf etf)
 
 let atom_of_etf = function
   | Etf.Atom atom -> Ok atom
-  | other -> Error(Failure (!%"atom_of_etf: %s" (Etf.show other)))
+  | other -> Error(Failure (!%"atom_of_etf: %s" (show_etf other)))
 
 let tuple_of_etf = function
   | Etf.SmallTuple(_, etfs) -> Ok etfs
-  | other -> Error(Failure (!%"tuple_of_etf: %s" (Etf.show other)))
+  | other -> Error(Failure (!%"tuple_of_etf: %s" (show_etf other)))
 
 let pair_of_etf etf =
   let open Result in
   tuple_of_etf etf >>= function
   | [x; y] -> Ok (x, y)
   | other ->
-     Error (Failure (!%"pair_of_etf: [%s]" (List.map ~f:Etf.show other |> String.concat ~sep:",")))
+     Error (Failure (!%"pair_of_etf: [%s]" (List.map ~f:show_etf other |> String.concat ~sep:",")))
 
 let list_of_etf = function
   | Etf.Nil -> Ok []
@@ -60,12 +60,12 @@ let list_of_etf = function
      |> List.map ~f:(fun char -> Etf.SmallInteger (Char.to_int char))
      |> Result.return
   | other ->
-     Error (Failure(!%"list_of_etf: '%s'" (Etf.show other)))
+     Error (Failure(!%"list_of_etf: '%s'" (show_etf other)))
 
 let int_of_etf = function
   | Etf.SmallInteger i -> Ok i
   | Etf.Integer i32 -> Ok (Int32.to_int_exn i32)
-  | other -> Error (Failure (!%"int_of_etf: %s" (Etf.show other)))
+  | other -> Error (Failure (!%"int_of_etf: %s" (show_etf other)))
 
 let list etfs = Etf.List(etfs, Etf.Nil)
 let small_tuple etfs = Etf.SmallTuple(List.length etfs, etfs)
@@ -110,7 +110,7 @@ let set_of_etf etf =
      Ok {set_size; set_num_of_active_slot; set_maxn; set_buddy_slot_offset;
          set_exp_size; set_con_size; set_empty_segment; set_segs}
   | _ ->
-     Error (Failure (!%"set_of_etf: %s" (Etf.show etf)))
+     Error (Failure (!%"set_of_etf: %s" (show_etf etf)))
 
 let fold_elist ~f ~init etf =
   match list_of_etf etf with
@@ -199,7 +199,7 @@ let dict_of_etf etf =
      Ok {dict_size; dict_num_of_active_slot; dict_maxn; dict_buddy_slot_offset;
          dict_exp_size; dict_con_size; dict_empty_segment; dict_segs}
   | other ->
-     Error (Failure (!%"dict_of_etf: %s" (Etf.show etf)))
+     Error (Failure (!%"dict_of_etf: %s" (show_etf etf)))
 
 let fold_dict ~f ~init dict =
   let segs = dict.dict_segs in
@@ -207,7 +207,7 @@ let fold_dict ~f ~init dict =
       match e with
       | List([k; v], Nil) -> f acc k v
       | List([k], v) -> f acc k v
-      | other -> failwith (!%"fold_dict: %s" (Etf.show other))
+      | other -> failwith (!%"fold_dict: %s" (show_etf other))
     ) ~init segs
 let dict_to_list dict =
   fold_dict ~f:(fun acc k v -> (k, v) :: acc) ~init:[] dict

--- a/lib/etf_util.mli
+++ b/lib/etf_util.mli
@@ -3,6 +3,7 @@ module Format = Caml.Format
 module Etf = Obeam.External_term_format
 
 type etf = Etf.t
+val show_etf : Etf.t -> string
 val sexp_of_etf : etf -> Sexplib0.Sexp.t
 
 val atom_of_etf : Etf.t -> (string, exn) Result.t

--- a/lib/plt.ml
+++ b/lib/plt.ml
@@ -34,7 +34,7 @@ let file_md5_of_etf = function
     ]) ->
      Ok {filename; binary = Bitstring.string_of_bitstring bin}
   | other ->
-     Error (Failure (!%"file_md5_of_etf error: %s" (Etf.show other)))
+     Error (Failure (!%"file_md5_of_etf error: %s" (E.show_etf other)))
 
 let file_plt_of_etf = function
   | Etf.SmallTuple(10, [
@@ -70,7 +70,7 @@ let file_plt_of_etf = function
          implementation_md5;
        }
   | other ->
-     Error (Failure (!%"file_plt_of_etf: %s" (Etf.show other)))
+     Error (Failure (!%"file_plt_of_etf: %s" (E.show_etf other)))
 
 (* ==========================================================================
    PLT
@@ -112,7 +112,7 @@ let ret_args_types_of_etf = function
      erl_type_of_etf v >>= fun ty ->
      Ok(ty, [])
   | other ->
-     Error (Failure (!%"ret_args_types_of_etf error: %s" (Etf.show other)))
+     Error (Failure (!%"ret_args_types_of_etf error: %s" (E.show_etf other)))
 *)
 
 type t = {
@@ -132,9 +132,9 @@ let mfa_of_etf = function
     ]) ->
      Ok (module_name, func, arity)
   | other ->
-     Error (Failure (!%"mfa_of_etf error: %s" (Etf.show other)))
+     Error (Failure (!%"mfa_of_etf error: %s" (E.show_etf other)))
 
-    
+
 let contr_constr_of_etf = function
   | Etf.SmallTuple(3, [
                      Atom "subtype";
@@ -145,7 +145,7 @@ let contr_constr_of_etf = function
      Erl_type.of_etf e2 >>= fun ty2 ->
      Ok (ty1, ty2)
   | other ->
-     Error (Failure (!%"contr_constr_of_etf error: %s" (Etf.show other)))
+     Error (Failure (!%"contr_constr_of_etf error: %s" (E.show_etf other)))
 
 let contract_of_etf = function
   | Etf.SmallTuple(4, [
@@ -170,7 +170,7 @@ let contract_of_etf = function
      (*TODO: result_map_m ~f:pair_of_etf form_etfs >>= fun forms -> *)
      Ok {contracts; args; forms=()}
   | other ->
-     Error (Failure (!%"contract_of_etf error: %s" (Etf.show other)))
+     Error (Failure (!%"contract_of_etf error: %s" (E.show_etf other)))
 
 let contracts_of_dict dict =
   let open Result in


### PR DESCRIPTION
This make External_term_format.t string like erlang code.

```ocaml
External_term_format.SmallTuple (2, [
  External_term_format.Atom "ok";
  External_term_format.List ([
    External_term_format.SmallTuple (4, [
      External_term_format.Atom "c";
      External_term_format.Atom "nil";
      External_term_format.Nil;
      External_term_format.Atom "unknown";
    ])
  ], External_term_format.Nil)
])
```
↓ Etf_util.show_etf
```erlang
{'ok', [{'c', 'nil', [], 'unknown'}]}
```