### PR TITLE
[issue 123] implement sup and inf

### DIFF
--- a/lib/bif.ml
+++ b/lib/bif.ml
@@ -1,11 +1,11 @@
 open Mfa
 let type_sigs = [
     ({module_name="erlang"; function_name="+"; arity=2},
-     Type.(TyFun ([TyNumber; TyNumber], TyNumber)));
+     Type.(of_elem (TyFun ([of_elem TyNumber; of_elem TyNumber], of_elem TyNumber))));
     ({module_name="erlang"; function_name="-"; arity=2},
-     Type.(TyFun ([TyNumber; TyNumber], TyNumber)));
+     Type.(of_elem (TyFun ([of_elem TyNumber; of_elem TyNumber], of_elem TyNumber))));
     ({module_name="erlang"; function_name="/"; arity=2},
-     Type.(TyFun ([TyNumber; TyNumber], TyNumber)));
+     Type.(of_elem (TyFun ([of_elem TyNumber; of_elem TyNumber], of_elem TyNumber))));
     ({module_name="erlang"; function_name="*"; arity=2},
-     Type.(TyFun ([TyNumber; TyNumber], TyNumber)));
+     Type.(of_elem (TyFun ([of_elem TyNumber; of_elem TyNumber], of_elem TyNumber))));
   ]

--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -172,41 +172,13 @@ let clauses_to_function = function
      let vs = args |> List.map ~f:f in
      (vs, expr_of_erlang_expr body)
 
-let rec typ_of_erlang_type = function
-(*  | F.TyAnn (_line, _, _) ->
-  | TyBitstring ->
- *)
-  | F.TyPredef (_line, "number", []) -> Type.TyNumber
-     (*
-  | TyProduct ->
-  | TyBinOp ->
-  | TyUnaryOp ->
-  | TyAnyMap ->
-  | TyMap ->
- *)
-  | F.TyVar (_line, v) -> Type.TyVar (Type_variable.of_string v)
-(*  | TyContFun ->
- *)
-  | TyFun (_line, _, args, range) ->
-     Type.TyFun(List.map ~f:typ_of_erlang_type args, typ_of_erlang_type range)
-(*
-  | TyAnyTuple ->
-  | TyTuple ->
-  | TyUnion ->
-  | TyUser ->
- *)
-  | TyLit (LitAtom (_, atom)) -> TySingleton (Atom atom)
-  | other ->
-     Log.debug [%here] "not implemented type: %s" (F.sexp_of_type_t other |> Sexp.to_string_hum);
-     Type.TyAny
-
 let forms_to_functions forms =
   let find_specs fun_name =
     List.find_map ~f:(function
                       | F.SpecFun (_line, _mod_name, fname, arity, specs) when fun_name = fname ->
                          List.map ~f:(fun ty ->
-                                    match typ_of_erlang_type ty with
-                                    | Type.TyFun (domains, range) -> (domains, range)
+                                    match Type.of_erlang ty with
+                                    | Type.(TyUnion [Type.TyFun (domains, range)]) -> (domains, range)
                                     | _ -> failwith (!%"unexpected type spec of %s" fname))
                                   specs
                          |> Option.return

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -51,7 +51,7 @@ and unify_elem elem inf =
   match (elem, inf) with
   | (TyNumber, _) | (TyAtom, _) | (TySingleton _, _) -> []
   | (TyVar v, _) ->
-     [v, inf]
+     [(v, inf)]
   | (TyTuple tys1, TyUnion [TyTuple tys2]) when List.length tys1 = List.length tys2 ->
      List.map2_exn ~f:unify tys1 tys2
      |> List.concat

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -14,28 +14,8 @@ let string_of_sol sol =
 
 let init : solution = Map.empty (module Type_variable)
 
-(* type_subst (X, τ_1) τ_2 := [X ↦ τ_1]τ_2 *)
-let rec type_subst (x, ty1): Type.t -> Type.t = function
-  | TyTuple tys ->
-     TyTuple(List.map ~f:(type_subst (x, ty1)) tys)
-  | TyFun (tys, ty) ->
-     TyFun (List.map ~f:(type_subst (x, ty1)) tys, type_subst (x, ty1) ty)
-  | TyUnion (ty_a, ty_b) ->
-     TyUnion(type_subst (x, ty1) ty_a, type_subst (x, ty1) ty_b)
-  | TyAny -> TyAny
-  | TyBottom -> TyBottom
-  | TyNumber -> TyNumber
-  | TyAtom -> TyAtom
-  | TySingleton const -> TySingleton const
-  | TyVar v ->
-     if x = v then ty1 else (TyVar v)
-
-let type_subst_to_sol (x, ty) sol =
-  Map.map ~f:(type_subst (x, ty)) sol
-
 let set (x, ty) sol =
-  let sol' = type_subst_to_sol (x, ty) sol in
-  Map.set sol' ~key:x ~data:ty
+  Map.set sol ~key:x ~data:ty
 
 let rec lookup_type sol = function
   | TyTuple tys ->

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -37,10 +37,16 @@ and lookup_elem sol = function
      | None -> TyAny
      end
 
-(* τ_1 ⊆ τ_2 *)
+(**
+  τ_1 ⊆ τ_2
+  assume no type variable in [ty1] and [ty2]
+ *)
 let is_subtype ty1 ty2 =
   Type.inf ty1 ty2 = ty1
 
+(**
+  assume no type variable in the 2nd argument [inf]
+ *)
 let rec unify ty inf =
   match ty with
   | TyUnion [elem] ->

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,4 +1,4 @@
-type solution = typ Base.Map.M(Type_variable).t (* public for test *)
+type solution = Type.t Base.Map.M(Type_variable).t (* public for test *)
 
 [@@deriving sexp_of]
 

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,4 +1,5 @@
-type solution
+type solution = typ Base.Map.M(Type_variable).t (* public for test *)
+
 [@@deriving sexp_of]
 
 val string_of_sol : solution -> string
@@ -7,4 +8,4 @@ val init : solution
 
 val solve : solution -> Type.constraint_ -> (solution, exn) result
 
-val lookup_type : solution -> t -> t
+val lookup_type : solution -> Type.t -> Type.t

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -7,5 +7,4 @@ val init : solution
 
 val solve : solution -> Type.constraint_ -> (solution, exn) result
 
-(* TODO: don't export *)
-val meet : Type.t -> Type.t -> Type.t
+val lookup_type : solution -> t -> t

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -14,11 +14,10 @@ type t =
     | TyVar of Type_variable.t
     | TyTuple of t list
     | TyFun of t list * t
-[@@deriving show, sexp_of]
+[@@deriving sexp_of]
 
 type typ = t
-[@@deriving show, sexp_of]
->>>>>>> [issue-123] `typ` type make 2 level mutual recursion
+[@@deriving sexp_of]
 
 type constraint_ =
     | Eq of t * t

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -44,6 +44,10 @@ and pp_t_union_elem = function
 let bool = TyUnion [TySingleton (Atom "true"); TySingleton (Atom "false")]
 let of_elem e = TyUnion [e]
 
+(**
+   supremum of two types: ty1 ∪ ty2
+   assume no type variable in the arguments
+ *)
 let rec sup ty1 ty2 =
   match (ty1, ty2) with
   | _ when ty1 = ty2 -> ty1
@@ -102,6 +106,10 @@ and sup_elems_to_list store = function
 let union_list tys =
   List.reduce_exn ~f:sup tys
 
+(**
+   infimum of two types: ty1 ∩ ty2
+   assume no type variable in the arguments
+ *)
 let rec inf ty1 ty2 =  (* ty1 and ty2 should be a TyAny, TyBottom, TyVar or TyUnion *)
   match (ty1, ty2) with
   | _ when ty1 = ty2 -> ty1

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -1,16 +1,24 @@
 open Base
+open Polymorphic_compare
+module F = Obeam.Abstract_format
+open Common
 
 type t =
-    | TyVar of Type_variable.t
-    | TyTuple of t list
-    | TyFun of t list * t
-    | TyUnion of t list (* all member of the list is not a union *)
+    | TyUnion of t_union_elem list (* has one or more elements *)
     | TyAny
     | TyBottom
+ and t_union_elem =
     | TyNumber
     | TyAtom
     | TySingleton of Constant.t
-[@@deriving sexp_of]
+    | TyVar of Type_variable.t
+    | TyTuple of t list
+    | TyFun of t list * t
+[@@deriving show, sexp_of]
+
+type typ = t
+[@@deriving show, sexp_of]
+>>>>>>> [issue-123] `typ` type make 2 level mutual recursion
 
 type constraint_ =
     | Eq of t * t
@@ -22,135 +30,124 @@ type constraint_ =
 
 (* ref: http://erlang.org/doc/reference_manual/typespec.html *)
 let rec pp = function
+  | TyUnion tys ->
+     List.map ~f:pp_t_union_elem tys |> String.concat ~sep:" | "
+  | TyAny -> "any()"
+  | TyBottom -> "none()"
+and pp_t_union_elem = function
+  | TyNumber -> "number()"
+  | TyAtom -> "atom()"
+  | TySingleton c -> Constant.pp c
   | TyVar var -> Type_variable.to_string var
   | TyTuple ts -> "{" ^ (ts |> List.map ~f:pp |> String.concat ~sep:", ") ^ "}"
   | TyFun (args, ret) ->
      let args_str = "(" ^ (args |> List.map ~f:pp |> String.concat ~sep:", ") ^ ")" in
      let ret_str = pp ret in
      "fun(" ^ args_str ^ " -> " ^ ret_str ^ ")"
-  | TyUnion tys ->
-     List.map ~f:pp tys |> String.concat ~sep:" | "
-  | TyAny -> "any()"
-  | TyBottom -> "none()"
-  | TyNumber -> "number()"
-  | TyAtom -> "atom()"
-  | TySingleton c -> Constant.pp c
 
 let bool = TyUnion [TySingleton (Atom "true"); TySingleton (Atom "false")]
+let of_elem e = TyUnion [e]
 
-
-let rec sup2 ty1 ty2 = (* ty1 and ty2 should be a TyAny, TyBottom, TyVar or TyUnion *)
+let rec sup ty1 ty2 =
   match (ty1, ty2) with
   | _ when ty1 = ty2 -> ty1
   | (TyAny, _) | (_, TyAny) -> TyAny
   | (TyBottom, ty) | (ty, TyBottom) -> ty
-  | (TyVar _, _) | (_, TyVar _) ->
-     failwith "cannotreach"
   | (TyUnion tys1, TyUnion tys2) ->
-     begin match sup1_list tys1 tys2 with
-     | [] -> TyBottom
-     | ty1s -> TyUnion ty1s
-     end
-  | _ -> failwith "cannot reach here"
-and sup1_list store = function (* all member of the list should be a TyNumber, TySingleton, TyAtom, TyTuple or TyFun *)
+     TyUnion (sup_elems_to_list tys1 tys2) (* has one or more element *)
+and sup_elems_to_list store = function
   | [] -> store
+  | TyVar _ :: _ -> failwith "cannot reach here"
   | ty1 :: ty1s when List.exists ~f:((=) ty1) store ->
-     sup1_list store ty1s
+     sup_elems_to_list store ty1s
   | TyNumber :: ty1s ->
      let is_not_number = function TySingleton (Number _) -> false | _ -> true in
      let store' = TyNumber :: List.filter ~f:is_not_number store in
-     sup1_list store' ty1s
+     sup_elems_to_list store' ty1s
   | TySingleton (Number n) :: ty1s when List.exists ~f:((=) TyNumber) store ->
-     sup1_list store ty1s
+     sup_elems_to_list store ty1s
   | TySingleton (Number n) :: ty1s ->
-     sup1_list (TySingleton (Number n) :: store) ty1s
+     sup_elems_to_list (TySingleton (Number n) :: store) ty1s
   | TyAtom :: ty1s ->
      let is_not_atom = function TySingleton (Atom _) -> false | _ -> true in
      let store' = TyAtom :: List.filter ~f:is_not_atom store in
-     sup1_list store' ty1s
+     sup_elems_to_list store' ty1s
   | TySingleton (Atom a) :: ty1s when List.exists ~f:((=) TyAtom) store ->
-     sup1_list store ty1s
+     sup_elems_to_list store ty1s
   | TySingleton (Atom a) :: ty1s ->
-     sup1_list (TySingleton (Atom a) :: store) ty1s
+     sup_elems_to_list (TySingleton (Atom a) :: store) ty1s
   | TyTuple ty2s :: ty1s ->
      let store' =
        if List.exists ~f:(function TyTuple tys when List.length ty2s = List.length tys -> true | _ -> false) store then
          List.map ~f:(function
                       | TyTuple tys when List.length ty2s = List.length tys ->
-                         List.map2_exn ~f:sup2 tys ty2s
+                         List.map2_exn ~f:sup tys ty2s
                          |> fun ty2s' -> TyTuple ty2s'
                       | t -> t)
                   store
        else
          TyTuple ty2s :: store
      in
-     sup1_list store' ty1s
+     sup_elems_to_list store' ty1s
   | TyFun (args, range) :: ty1s ->
      let store' =
        if List.exists ~f:(function TyFun (args0, _) when List.length args0 = List.length args -> true | _ -> false) store then
          List.map ~f:(function
                       | TyFun (args0, range0) when List.length args0 = List.length args ->
-                         List.map2_exn ~f:sup2 args0 args
+                         List.map2_exn ~f:sup args0 args
                          |> fun ty2s' -> TyTuple ty2s'
                       | t -> t)
                   store
        else
          TyFun (args, range) :: store
      in
-     sup1_list store' ty1s
-  | _ -> failwith "cannot reach here"
-
-let sup ty1 ty2 =
-  let f = function
-    | TyNumber | TyAtom | TySingleton _ | TyTuple _ | TyFun _ as t -> TyUnion [t]
-    | t -> t
-  in
-  sup2 (f ty1) (f ty2)
+     sup_elems_to_list store' ty1s
 
 let union_list tys =
   List.reduce_exn ~f:sup tys
 
-let rec inf2 ty1 ty2 =  (* ty1 and ty2 should be a TyAny, TyBottom, TyVar or TyUnion *)
+let rec inf ty1 ty2 =  (* ty1 and ty2 should be a TyAny, TyBottom, TyVar or TyUnion *)
   match (ty1, ty2) with
   | _ when ty1 = ty2 -> ty1
   | (TyAny, ty) | (ty, TyAny) -> ty
   | (TyBottom, _) | (_, TyBottom) -> TyBottom
-  | (TyVar _, _) | (_, TyVar _) ->
-     failwith "cannotreach"
   | (TyUnion tys1, TyUnion tys2) ->
      let ty1s =
        List.cartesian_product tys1 tys2
-       |> List.filter_map ~f:(fun (ty1, ty2) -> inf1 ty1 ty2)
+       |> List.filter_map ~f:(fun (ty1, ty2) -> inf_elem ty1 ty2)
      in
-     begin match sup1_list [] ty1s with
+     begin match sup_elems_to_list [] ty1s with
      | [] -> TyBottom
      | ty1s -> TyUnion ty1s
      end
-  | _ -> failwith "cannot reach here"
-and inf1 ty1 ty2 =  (* ty1 and ty2 should be a TyNumber, TySingleton, TyAtom, TyTuple or TyFun *)
+and inf_elem ty1 ty2 =  (* ty1 and ty2 should be a TyNumber, TySingleton, TyAtom, TyTuple or TyFun *)
   match (ty1, ty2) with
+  | (TyVar _, _) | (_, TyVar _) -> failwith "cannot reach here"
   | _ when ty1 = ty2 -> Some ty1
   | (TyNumber, TySingleton (Number n)) | (TySingleton (Number n), TyNumber) ->
      Some (TySingleton (Number n))
   | (TyAtom, TySingleton (Atom a)) | (TySingleton (Atom a), TyAtom) ->
      Some (TySingleton (Atom a))
   | (TyTuple tys1, TyTuple tys2) when List.length tys1 = List.length tys2 ->
-     List.map2_exn ~f:inf2 tys1 tys2
+     List.map2_exn ~f:inf tys1 tys2
      |> fun tys -> Some (TyTuple tys)
   | (TyFun (args1, range1), TyFun (args2, range2)) ->
-     let args' = List.map2_exn ~f:inf2 args1 args2 in
-     let range' = inf2 range1 range2 in
+     let args' = List.map2_exn ~f:inf args1 args2 in
+     let range' = inf range1 range2 in
      Some (TyFun (args', range'))
-  | (TyAny, _) | (_, TyAny) | (TyBottom, _) | (_, TyBottom) | (TyVar _, _) | (_, TyVar _) | (TyUnion _, _) | (_, TyUnion _) ->
-     failwith "cannot reach here"
   | (_, _) ->
      None
 
-let inf ty1 ty2 =
-  let f = function
-    | TyNumber | TyAtom | TySingleton _ | TyTuple _ | TyFun _ as t -> TyUnion [t]
-    | t -> t
-  in
-  match inf2 (f ty1) (f ty2) with
-  | TyUnion [t] -> t
-  | t -> t
+let rec of_erlang = function
+  | F.TyUnion (_line, ts) ->
+     TyUnion (List.map ~f:elem_of_erlang ts)
+  | t ->
+     of_elem [elem_of_erlang t]
+and elem_of_erlang = function
+  | F.TyPredef (_line, "number", []) -> TyNumber
+  | F.TyLit (LitAtom (_, atom)) -> TySingleton (Atom atom)
+  | F.TyVar (_line, v) -> TyVar (Type_variable.of_string v)
+  | TyFun (_line, _, args, range) ->
+     TyFun(List.map ~f:of_erlang args, of_erlang range)
+  | other ->
+     failwith (!%"not implemented conversion from type: %s" (F.sexp_of_type_t other |> Sexp.to_string_hum))

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -4,7 +4,7 @@ type t =
     | TyVar of Type_variable.t
     | TyTuple of t list
     | TyFun of t list * t
-    | TyUnion of t * t
+    | TyUnion of t list (* all member of the list is not a union *)
     | TyAny
     | TyBottom
     | TyNumber
@@ -28,9 +28,129 @@ let rec pp = function
      let args_str = "(" ^ (args |> List.map ~f:pp |> String.concat ~sep:", ") ^ ")" in
      let ret_str = pp ret in
      "fun(" ^ args_str ^ " -> " ^ ret_str ^ ")"
-  | TyUnion (tyl, tyr) -> pp tyl ^ " | " ^ pp tyr
+  | TyUnion tys ->
+     List.map ~f:pp tys |> String.concat ~sep:" | "
   | TyAny -> "any()"
   | TyBottom -> "none()"
   | TyNumber -> "number()"
   | TyAtom -> "atom()"
   | TySingleton c -> Constant.pp c
+
+let bool = TyUnion [TySingleton (Atom "true"); TySingleton (Atom "false")]
+
+
+let rec sup2 ty1 ty2 = (* ty1 and ty2 should be a TyAny, TyBottom, TyVar or TyUnion *)
+  match (ty1, ty2) with
+  | _ when ty1 = ty2 -> ty1
+  | (TyAny, _) | (_, TyAny) -> TyAny
+  | (TyBottom, ty) | (ty, TyBottom) -> ty
+  | (TyVar _, _) | (_, TyVar _) ->
+     failwith "cannotreach"
+  | (TyUnion tys1, TyUnion tys2) ->
+     begin match sup1_list tys1 tys2 with
+     | [] -> TyBottom
+     | ty1s -> TyUnion ty1s
+     end
+  | _ -> failwith "cannot reach here"
+and sup1_list store = function (* all member of the list should be a TyNumber, TySingleton, TyAtom, TyTuple or TyFun *)
+  | [] -> store
+  | ty1 :: ty1s when List.exists ~f:((=) ty1) store ->
+     sup1_list store ty1s
+  | TyNumber :: ty1s ->
+     let is_not_number = function TySingleton (Number _) -> false | _ -> true in
+     let store' = TyNumber :: List.filter ~f:is_not_number store in
+     sup1_list store' ty1s
+  | TySingleton (Number n) :: ty1s when List.exists ~f:((=) TyNumber) store ->
+     sup1_list store ty1s
+  | TySingleton (Number n) :: ty1s ->
+     sup1_list (TySingleton (Number n) :: store) ty1s
+  | TyAtom :: ty1s ->
+     let is_not_atom = function TySingleton (Atom _) -> false | _ -> true in
+     let store' = TyAtom :: List.filter ~f:is_not_atom store in
+     sup1_list store' ty1s
+  | TySingleton (Atom a) :: ty1s when List.exists ~f:((=) TyAtom) store ->
+     sup1_list store ty1s
+  | TySingleton (Atom a) :: ty1s ->
+     sup1_list (TySingleton (Atom a) :: store) ty1s
+  | TyTuple ty2s :: ty1s ->
+     let store' =
+       if List.exists ~f:(function TyTuple tys when List.length ty2s = List.length tys -> true | _ -> false) store then
+         List.map ~f:(function
+                      | TyTuple tys when List.length ty2s = List.length tys ->
+                         List.map2_exn ~f:sup2 tys ty2s
+                         |> fun ty2s' -> TyTuple ty2s'
+                      | t -> t)
+                  store
+       else
+         TyTuple ty2s :: store
+     in
+     sup1_list store' ty1s
+  | TyFun (args, range) :: ty1s ->
+     let store' =
+       if List.exists ~f:(function TyFun (args0, _) when List.length args0 = List.length args -> true | _ -> false) store then
+         List.map ~f:(function
+                      | TyFun (args0, range0) when List.length args0 = List.length args ->
+                         List.map2_exn ~f:sup2 args0 args
+                         |> fun ty2s' -> TyTuple ty2s'
+                      | t -> t)
+                  store
+       else
+         TyFun (args, range) :: store
+     in
+     sup1_list store' ty1s
+  | _ -> failwith "cannot reach here"
+
+let sup ty1 ty2 =
+  let f = function
+    | TyNumber | TyAtom | TySingleton _ | TyTuple _ | TyFun _ as t -> TyUnion [t]
+    | t -> t
+  in
+  sup2 (f ty1) (f ty2)
+
+let union_list tys =
+  List.reduce_exn ~f:sup tys
+
+let rec inf2 ty1 ty2 =  (* ty1 and ty2 should be a TyAny, TyBottom, TyVar or TyUnion *)
+  match (ty1, ty2) with
+  | _ when ty1 = ty2 -> ty1
+  | (TyAny, ty) | (ty, TyAny) -> ty
+  | (TyBottom, _) | (_, TyBottom) -> TyBottom
+  | (TyVar _, _) | (_, TyVar _) ->
+     failwith "cannotreach"
+  | (TyUnion tys1, TyUnion tys2) ->
+     let ty1s =
+       List.cartesian_product tys1 tys2
+       |> List.filter_map ~f:(fun (ty1, ty2) -> inf1 ty1 ty2)
+     in
+     begin match sup1_list [] ty1s with
+     | [] -> TyBottom
+     | ty1s -> TyUnion ty1s
+     end
+  | _ -> failwith "cannot reach here"
+and inf1 ty1 ty2 =  (* ty1 and ty2 should be a TyNumber, TySingleton, TyAtom, TyTuple or TyFun *)
+  match (ty1, ty2) with
+  | _ when ty1 = ty2 -> Some ty1
+  | (TyNumber, TySingleton (Number n)) | (TySingleton (Number n), TyNumber) ->
+     Some (TySingleton (Number n))
+  | (TyAtom, TySingleton (Atom a)) | (TySingleton (Atom a), TyAtom) ->
+     Some (TySingleton (Atom a))
+  | (TyTuple tys1, TyTuple tys2) when List.length tys1 = List.length tys2 ->
+     List.map2_exn ~f:inf2 tys1 tys2
+     |> fun tys -> Some (TyTuple tys)
+  | (TyFun (args1, range1), TyFun (args2, range2)) ->
+     let args' = List.map2_exn ~f:inf2 args1 args2 in
+     let range' = inf2 range1 range2 in
+     Some (TyFun (args', range'))
+  | (TyAny, _) | (_, TyAny) | (TyBottom, _) | (_, TyBottom) | (TyVar _, _) | (_, TyVar _) | (TyUnion _, _) | (_, TyUnion _) ->
+     failwith "cannot reach here"
+  | (_, _) ->
+     None
+
+let inf ty1 ty2 =
+  let f = function
+    | TyNumber | TyAtom | TySingleton _ | TyTuple _ | TyFun _ as t -> TyUnion [t]
+    | t -> t
+  in
+  match inf2 (f ty1) (f ty2) with
+  | TyUnion [t] -> t
+  | t -> t

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -127,7 +127,7 @@ and inf_elem ty1 ty2 =  (* ty1 and ty2 should be a TyNumber, TySingleton, TyAtom
   | (TyTuple tys1, TyTuple tys2) when List.length tys1 = List.length tys2 ->
      List.map2_exn ~f:inf tys1 tys2
      |> fun tys -> Some (TyTuple tys)
-  | (TyFun (args1, range1), TyFun (args2, range2)) ->
+  | (TyFun (args1, range1), TyFun (args2, range2)) when List.length args1 = List.length args2 ->
      let args' = List.map2_exn ~f:inf args1 args2 in
      let range' = inf range1 range2 in
      Some (TyFun (args', range'))

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -16,9 +16,6 @@ type t =
     | TyFun of t list * t
 [@@deriving sexp_of]
 
-type typ = t
-[@@deriving sexp_of]
-
 type constraint_ =
     | Eq of t * t
     | Subtype of t * t

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -142,7 +142,7 @@ let rec of_erlang = function
   | F.TyUnion (_line, ts) ->
      TyUnion (List.map ~f:elem_of_erlang ts)
   | t ->
-     of_elem [elem_of_erlang t]
+     of_elem (elem_of_erlang t)
 and elem_of_erlang = function
   | F.TyPredef (_line, "number", []) -> TyNumber
   | F.TyLit (LitAtom (_, atom)) -> TySingleton (Atom atom)

--- a/test/unit-test/test_type.ml
+++ b/test/unit-test/test_type.ml
@@ -59,7 +59,7 @@ let%expect_test "pp" =
 let%expect_test "inf" =
   let print ty1 ty2 =
     inf ty1 ty2
-    |> [%sexp_of: typ]
+    |> [%sexp_of: Type.t]
     |> Expect_test_helpers_kernel.print_s in
 
   print TyAny TyAny;

--- a/test/unit-test/test_type.ml
+++ b/test/unit-test/test_type.ml
@@ -86,3 +86,33 @@ let%expect_test "inf" =
       (TySingleton (Number 2))
       (TySingleton (Number 1))))
             |}]
+
+let%expect_test "sup" =
+  let print ty1 ty2 =
+    sup ty1 ty2
+    |> [%sexp_of: Type.t]
+    |> Expect_test_helpers_kernel.print_s in
+
+  print TyAny TyAny;
+  [%expect {| TyAny |}];
+
+  print TyBottom TyAny;
+  [%expect {| TyAny |}];
+
+  print (of_elem (TySingleton (Number 1))) (of_elem (TySingleton (Number 2)));
+  [%expect {|
+    (TyUnion (
+      (TySingleton (Number 2))
+      (TySingleton (Number 1)))) |}];
+
+  print (TyUnion [TySingleton (Number 1); TySingleton (Number 2); TySingleton (Number 3); ])
+        (TyUnion [TySingleton (Number 2); TySingleton (Number 3); TySingleton (Number 4); ]);
+  [%expect {|
+    (TyUnion (
+      (TySingleton (Number 4))
+      (TySingleton (Number 1))
+      (TySingleton (Number 2))
+      (TySingleton (Number 3)))) |}];
+
+  print (TyUnion [TySingleton (Number 1); TySingleton (Number 2); TySingleton (Number 3);]) (of_elem TyNumber);
+  [%expect {| (TyUnion (TyNumber)) |}]

--- a/test/unit-test/test_type.ml
+++ b/test/unit-test/test_type.ml
@@ -11,43 +11,78 @@ let%expect_test "pp" =
   print TyBottom;
   [%expect {| none() |}];
 
-  print TyAtom;
+  print (of_elem TyAtom);
   [%expect {| atom() |}];
 
-  print TyNumber;
+  print (of_elem TyNumber);
   [%expect {| number() |}];
 
-  print (TySingleton (Number 1));
+  print (of_elem (TySingleton (Number 1)));
   [%expect {| 1 |}];
 
-  print (TySingleton (Atom "ok"));
+  print (of_elem (TySingleton (Atom "ok")));
   [%expect {| 'ok' |}];
 
   (* single union *)
-  print (TyUnion (TyAtom, TyNumber));
+  print (TyUnion [TyAtom; TyNumber]);
   [%expect {| atom() | number() |}];
 
   (* multi union *)
-  print (TyUnion (TyUnion (TyUnion (TySingleton (Number 1), TySingleton (Number 2)), TySingleton (Number 3)),
-                  TyUnion (TyUnion (TySingleton (Number 4), TySingleton (Number 5)), TySingleton (Number 6))));
+  print (TyUnion [ TySingleton (Number 1); TySingleton (Number 2); TySingleton (Number 3);
+                   TySingleton (Number 4); TySingleton (Number 5); TySingleton (Number 6); ]);
   [%expect {| 1 | 2 | 3 | 4 | 5 | 6 |}];
 
-  print (TyVar (Type_variable.of_string "T"));
+  print (of_elem (TyVar (Type_variable.of_string "T")));
   [%expect {| T |}];
 
-  print (TyTuple [TyAny; TyTuple [TyBottom; TyBottom]]);
+  print (of_elem (TyTuple [TyAny; of_elem (TyTuple [TyBottom; TyBottom])]));
   [%expect {| {any(), {none(), none()}} |}];
 
   (* fun with no args *)
-  print (TyFun ([], TySingleton (Atom "ok")));
+  print (of_elem (TyFun ([], (of_elem (TySingleton (Atom "ok"))))));
   [%expect {| fun(() -> 'ok') |}];
 
   (* fun with some args *)
-  print (TyFun ([TyNumber; TyNumber], TyNumber));
+  print (of_elem (TyFun ([of_elem TyNumber; of_elem TyNumber], of_elem TyNumber)));
   [%expect {| fun((number(), number()) -> number()) |}];
 
   (* complex example *)
-  print (TyFun ([TyFun ([TyNumber; TyAtom], TyVar (Type_variable.of_string "A")); TyTuple [TyNumber; TyAtom]],
-                TyUnion (TyTuple [TySingleton (Atom "ok"); TyVar (Type_variable.of_string "A")],
-                         TyTuple [TySingleton (Atom "error"); TyAny])));
-  [%expect {| fun((fun((number(), atom()) -> A), {number(), atom()}) -> {'ok', A} | {'error', any()}) |}];
+  print (of_elem (TyFun (
+                      [
+                        of_elem (TyFun ([of_elem TyNumber; of_elem TyAtom], of_elem (TyVar (Type_variable.of_string "A"))));
+                        of_elem (TyTuple [of_elem TyNumber; of_elem TyAtom])
+                      ],
+                      TyUnion [TyTuple [of_elem (TySingleton (Atom "ok")); of_elem (TyVar (Type_variable.of_string "A"))];
+                               TyTuple [of_elem (TySingleton (Atom "error")); TyAny]])));
+  [%expect {| fun((fun((number(), atom()) -> A), {number(), atom()}) -> {'ok', A} | {'error', any()}) |}]
+
+let%expect_test "inf" =
+  let print ty1 ty2 =
+    inf ty1 ty2
+    |> [%sexp_of: typ]
+    |> Expect_test_helpers_kernel.print_s in
+
+  print TyAny TyAny;
+  [%expect {| TyAny |}];
+
+  print TyBottom TyAny;
+  [%expect {| TyBottom |}];
+
+  print (of_elem (TySingleton (Number 1))) (of_elem (TySingleton (Number 2)));
+  [%expect {| TyBottom |}];
+
+  print (TyUnion [TySingleton (Number 1); TySingleton (Number 2); TySingleton (Number 3); ])
+        (TyUnion [TySingleton (Number 2); TySingleton (Number 3); TySingleton (Number 4); ]);
+  [%expect {|
+    (TyUnion (
+      (TySingleton (Number 3))
+      (TySingleton (Number 2))))
+ |}];
+
+  print (TyUnion [TySingleton (Number 1); TySingleton (Number 2); TySingleton (Number 3);]) (of_elem TyNumber);
+  [%expect {|
+    (TyUnion (
+      (TySingleton (Number 3))
+      (TySingleton (Number 2))
+      (TySingleton (Number 1))))
+            |}]


### PR DESCRIPTION
- change `Type.t` type data structure
    - make definition of `Type.t` mutually recursive with `t_union_elem`
- implement sup and inf of types
    - Delete `Solver.meet` and introduce `Type.inf` instead.
    - Introduce `Type.sup`
- change printer of type in some unit testings

for #123