### PR TITLE
Support match expressions

### DIFF
--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -276,8 +276,13 @@ and expr_of_erlang_expr = function
        arity=Constant (Number (List.length args))} in
      App (mfa, List.map ~f:expr_of_erlang_expr args)
   | ExprMatch (line_t, pat, e) ->
-     (* TODO: support match expr `A = B` *)
-     raise Known_error.(FialyzerError (NotImplemented {issue_links=["https://github.com/dwango/fialyzer/issues/81"]; message="support match expr `A = B`"}))
+     (* There is no match expression in `e` by `extract_match_expr`.
+      * Futhermore, this match expression is single or the last of expr sequence because
+      * a match expression which has subsequent expressions is caught in `expr_of_erlang_exprs`.
+      * Therefore, we can put right-hand side expr of match expression to the return value of case expr.
+      *)
+     let e' = expr_of_erlang_expr e in
+     Case (e', [((pattern_of_erlang_pattern pat, Constant (Atom "true")), e')])
   | ExprBinOp (_line_t, op, e1, e2) ->
      let func = Ast.MFA {
         module_name = Constant (Atom "erlang");

--- a/lib/from_erlang.mli
+++ b/lib/from_erlang.mli
@@ -6,3 +6,6 @@ val expr_of_erlang_expr : Abstract_format.expr_t -> Ast.t
 val code_to_module : Abstract_format.t -> (Ast.module_, exn) Result.t
 
 val code_to_expr : Abstract_format.t -> (Ast.t, exn) Result.t
+
+(* export for unit-test *)
+val extract_match_expr : Abstract_format.expr_t -> Abstract_format.expr_t list

--- a/test/unit-test/test_from_erlang.ml
+++ b/test/unit-test/test_from_erlang.ml
@@ -178,4 +178,279 @@ let%expect_test "from_erlang" =
   [%expect {|
     (ListCons
       (Constant (Number 97))
-      (ListCons (Constant (Number 98)) (ListCons (Constant (Number 99)) ListNil))) |}];
+      (ListCons (Constant (Number 98)) (ListCons (Constant (Number 99)) ListNil))) |}]
+
+let%expect_test "extract_match_expr" =
+  let print expr =
+    extract_match_expr expr
+    |> [%sexp_of: expr_t list]
+    |> Expect_test_helpers_kernel.print_s
+  in
+
+  (* input: A = B *)
+  (* output: A = B *)
+  print (ExprMatch (1, PatVar (2, "A"), ExprVar (3, "B")));
+  [%expect {|
+    ((
+      ExprMatch 1
+      (PatVar  2 A)
+      (ExprVar 3 B))) |}];
+
+  (* input: A = B = C *)
+  (* output: B = C, A = B *)
+  print (ExprMatch (1, PatVar (2, "A"), ExprMatch (3, PatVar (4, "B"), ExprVar (5, "C"))));
+  [%expect {|
+    ((ExprMatch 3
+       (PatVar  4 B)
+       (ExprVar 5 C))
+     (ExprMatch 1
+       (PatVar  2 A)
+       (ExprVar 5 C))) |}];
+
+  (* input: ExprBody [A = B = C, A] *)
+  (* output: ExprBody [B = C, A = C, A] *)
+  print (ExprBody [ExprMatch (1, PatVar (2, "A"), ExprMatch (3, PatVar (4, "B"), ExprVar (5, "C")));
+                   ExprVar (6, "A")]);
+  [%expect {|
+    ((
+      ExprBody (
+        (ExprMatch 3
+          (PatVar  4 B)
+          (ExprVar 5 C))
+        (ExprMatch 1
+          (PatVar  2 A)
+          (ExprVar 5 C))
+        (ExprVar 6 A)))) |}];
+
+  (* input: case A = B of C -> D = E = F; G -> H = I = J end *)
+  (* output: A = B, case B of C -> E = F, D = F; G -> I = J, H = J end *)
+  print (ExprCase (1, ExprMatch (2, PatVar (3, "A"), ExprVar (4, "B")),
+                   [ClsCase (5, PatVar (6, "C"), None,
+                             ExprMatch (7, PatVar (8, "D"), ExprMatch (9, PatVar (10, "E"), ExprVar (11, "F"))));
+                    ClsCase (5, PatVar (12, "G"), None,
+                             ExprMatch (13, PatVar (14, "H"), ExprMatch (15, PatVar (16, "I"), ExprVar (17, "J"))))]));
+  [%expect {|
+    ((ExprMatch 2
+       (PatVar  3 A)
+       (ExprVar 4 B))
+     (ExprCase 1
+       (ExprVar 4 B)
+       ((ClsCase 5
+          (PatVar 6 C)
+          ()
+          (ExprBody (
+            (ExprMatch 9
+              (PatVar  10 E)
+              (ExprVar 11 F))
+            (ExprMatch 7
+              (PatVar  8  D)
+              (ExprVar 11 F)))))
+        (ClsCase 5
+          (PatVar 12 G)
+          ()
+          (ExprBody (
+            (ExprMatch 15
+              (PatVar  16 I)
+              (ExprVar 17 J))
+            (ExprMatch 13
+              (PatVar  14 H)
+              (ExprVar 17 J)))))))) |}];
+
+  (* input: [ N = 1 | M = 2 ] *)
+  (* output: N = 1, M = 2, [ 1 | 2 ] *)
+  print (ExprCons (1,
+                   ExprMatch (2, PatVar (3, "N"), ExprLit (LitInteger (4, 1))),
+                   ExprMatch (5, PatVar (6, "M"), ExprLit (LitInteger (7, 2)))));
+  [%expect {|
+    ((ExprMatch 2 (PatVar 3 N) (ExprLit (LitInteger 4 1)))
+     (ExprMatch 5 (PatVar 6 M) (ExprLit (LitInteger 7 2)))
+     (ExprCons 1
+       (ExprLit (LitInteger 4 1))
+       (ExprLit (LitInteger 7 2)))) |}];
+
+  (* input: [] *)
+  (* output: [] *)
+  print (ExprNil 1);
+  [%expect {| ((ExprNil 1)) |}];
+
+  (* TODO *)
+  (* input: [ A = B || B <- [C = D = 1], (E = 2) =:= (F = 3) ] *)
+  (* output: ? *)
+
+  (* input: fun f/0 *)
+  (* output: fun f/0 *)
+  print (ExprLocalFunRef (1, "f", 0));
+  [%expect {| ((ExprLocalFunRef 1 f 0)) |}];
+
+  (* input: fun m:f/0 *)
+  (* output: fun m:f/0 *)
+  print (ExprRemoteFunRef (1, AtomVarAtom (2, "m"), AtomVarAtom (3, "f"), IntegerVarInteger (4, 0)));
+  [%expect {|
+    ((
+      ExprRemoteFunRef 1
+      (AtomVarAtom       2 m)
+      (AtomVarAtom       3 f)
+      (IntegerVarInteger 4 0))) |}];
+
+  (* input: fun () -> A = B = C; () -> D = E = F end *)
+  (* output: fun () -> B = C, A = C; () -> E = F, D = F end *)
+  print (ExprFun (1, None,
+                  [ClsFun (2, [], None, ExprMatch (3, PatVar (4, "A"), ExprMatch (5, PatVar (6, "B"), ExprVar (7, "C"))));
+                   ClsFun (8, [], None, ExprMatch (9, PatVar (10, "D"), ExprMatch (11, PatVar (12, "E"), ExprVar (13, "F"))))]));
+  [%expect {|
+    ((
+      ExprFun 1
+      ()
+      ((ClsFun 2
+         ()
+         ()
+         (ExprBody (
+           (ExprMatch 5
+             (PatVar  6 B)
+             (ExprVar 7 C))
+           (ExprMatch 3
+             (PatVar  4 A)
+             (ExprVar 7 C)))))
+       (ClsFun 8
+         ()
+         ()
+         (ExprBody (
+           (ExprMatch 11
+             (PatVar  12 E)
+             (ExprVar 13 F))
+           (ExprMatch 9
+             (PatVar  10 D)
+             (ExprVar 13 F)))))))) |}];
+
+  (* input: f(N = 1, M = 2) *)
+  (* output: M = 2, N = 1, f(1, 2) *)
+  print (ExprLocalCall (1, ExprVar (2, "f"), [ExprMatch (3, PatVar (4, "N"), ExprLit (LitInteger (6, 1)));
+                                              ExprMatch (7, PatVar (8, "M"), ExprLit (LitInteger (10, 2)))]));
+  [%expect {|
+    ((ExprMatch 7 (PatVar 8 M) (ExprLit (LitInteger 10 2)))
+     (ExprMatch 3 (PatVar 4 N) (ExprLit (LitInteger 6 1)))
+     (ExprLocalCall 1
+       (ExprVar 2 f)
+       ((ExprLit (LitInteger 6  1))
+        (ExprLit (LitInteger 10 2))))) |}];
+
+  (* input: (M = m):(F = f)(A = 1, B = 2) *)
+  (* output: M = m, F = f, B = 2, A = 1, m:f(1, 2) *)
+  print (ExprRemoteCall (1, 2,
+                         ExprMatch (3, PatVar (4, "M"), ExprLit (LitAtom (5, "m"))),
+                         ExprMatch (6, PatVar (7, "F"), ExprLit (LitAtom (8, "f"))),
+                         [ExprMatch (9, PatVar (10, "A"), ExprLit (LitInteger (11, 1)));
+                          ExprMatch (12, PatVar (13, "B"), ExprLit (LitInteger (14, 2)))]));
+  [%expect {|
+    ((ExprMatch 3 (PatVar 4 M) (ExprLit (LitAtom 5 m)))
+     (ExprMatch 6 (PatVar 7 F) (ExprLit (LitAtom 8 f)))
+     (ExprMatch 12 (PatVar 13 B) (ExprLit (LitInteger 14 2)))
+     (ExprMatch 9 (PatVar 10 A) (ExprLit (LitInteger 11 1)))
+     (ExprRemoteCall 1 2
+       (ExprLit (LitAtom 5 m))
+       (ExprLit (LitAtom 8 f))
+       ((ExprLit (LitInteger 11 1))
+        (ExprLit (LitInteger 14 2))))) |}];
+
+  (* input: #{K1 = k1 => V1 = v1, K2 = k2 := V2 = v2} *)
+  (* output: K2 = k2, V2 = v2, K1 = k1, V1 = v1, #{k1 => v1, k2 := v2} *)
+  print (ExprMapCreation (1,
+                          [ExprAssoc (2,
+                                      ExprMatch (3, PatVar (4, "K1"), ExprLit (LitAtom (5, "k1"))),
+                                      ExprMatch (6, PatVar (7, "V1"), ExprLit (LitAtom (8, "v1"))));
+                           ExprAssocExact (9,
+                                           ExprMatch (10, PatVar (11, "K2"), ExprLit (LitAtom (12, "k2"))),
+                                           ExprMatch (15, PatVar (14, "V2"), ExprLit (LitAtom (13, "v2"))))]));
+  [%expect {|
+    ((ExprMatch 10 (PatVar 11 K2) (ExprLit (LitAtom 12 k2)))
+     (ExprMatch 15 (PatVar 14 V2) (ExprLit (LitAtom 13 v2)))
+     (ExprMatch 3 (PatVar 4 K1) (ExprLit (LitAtom 5 k1)))
+     (ExprMatch 6 (PatVar 7 V1) (ExprLit (LitAtom 8 v1)))
+     (ExprMapCreation 1 (
+       (ExprAssoc 2
+         (ExprLit (LitAtom 5 k1))
+         (ExprLit (LitAtom 8 v1)))
+       (ExprAssocExact 9
+         (ExprLit (LitAtom 12 k2))
+         (ExprLit (LitAtom 13 v2)))))) |}];
+
+  (* input: (M = #{})#{K1 = k1 => V1 = v1, K2 = k2 => V2 = v2} *)
+  (* output: K2 = k2, V2 = v2, K1 = k1, V1 = v1, #{k1 => v1, k2 => v2} *)
+  print (ExprMapCreation (1,
+                          [ExprAssoc (2,
+                                      ExprMatch (3, PatVar (4, "K1"), ExprLit (LitAtom (5, "k1"))),
+                                      ExprMatch (6, PatVar (7, "V1"), ExprLit (LitAtom (8, "v1"))));
+                           ExprAssoc (9,
+                                      ExprMatch (10, PatVar (11, "K2"), ExprLit (LitAtom (12, "k2"))),
+                                      ExprMatch (15, PatVar (14, "V2"), ExprLit (LitAtom (13, "v2"))))]));
+  [%expect {|
+    ((ExprMatch 10 (PatVar 11 K2) (ExprLit (LitAtom 12 k2)))
+     (ExprMatch 15 (PatVar 14 V2) (ExprLit (LitAtom 13 v2)))
+     (ExprMatch 3 (PatVar 4 K1) (ExprLit (LitAtom 5 k1)))
+     (ExprMatch 6 (PatVar 7 V1) (ExprLit (LitAtom 8 v1)))
+     (ExprMapCreation 1 (
+       (ExprAssoc 2
+         (ExprLit (LitAtom 5 k1))
+         (ExprLit (LitAtom 8 v1)))
+       (ExprAssoc 9
+         (ExprLit (LitAtom 12 k2))
+         (ExprLit (LitAtom 13 v2)))))) |}];
+
+  (* input: (M = #{})#{K1 = k1 => V1 = v1, K2 = k2 := V2 = v2} *)
+  (* output: M = #{}, K2 = k2, V2 = v2, K1 = k2, V1 = v2, (#{})#{k1 => v1, k2 => v2} *)
+  print (ExprMapUpdate (1,
+                        ExprMatch (2, PatVar (3, "M"), ExprMapCreation (4, [])),
+                        [ExprAssoc (5,
+                                    ExprMatch (6, PatVar (7, "K1"), ExprLit (LitAtom (8, "k1"))),
+                                    ExprMatch (9, PatVar (10, "V1"), ExprLit (LitAtom (11, "v1"))));
+                         ExprAssocExact (12,
+                                         ExprMatch (13, PatVar (14, "K2"), ExprLit (LitAtom (15, "k2"))),
+                                         ExprMatch (16, PatVar (17, "V2"), ExprLit (LitAtom (18, "v2"))))]));
+  [%expect {|
+    ((ExprMatch 2 (PatVar 3 M) (ExprMapCreation 4 ()))
+     (ExprMatch 13 (PatVar 14 K2) (ExprLit (LitAtom 15 k2)))
+     (ExprMatch 16 (PatVar 17 V2) (ExprLit (LitAtom 18 v2)))
+     (ExprMatch 6 (PatVar 7 K1) (ExprLit (LitAtom 8 k1)))
+     (ExprMatch 9 (PatVar 10 V1) (ExprLit (LitAtom 11 v1)))
+     (ExprMapUpdate 1
+       (ExprMapCreation 4 ())
+       ((ExprAssoc 5
+          (ExprLit (LitAtom 8  k1))
+          (ExprLit (LitAtom 11 v1)))
+        (ExprAssocExact 12
+          (ExprLit (LitAtom 15 k2))
+          (ExprLit (LitAtom 18 v2)))))) |}];
+
+  (* input: (N = 1) + (M = 2) *)
+  (* output: N = 1, M = 2, 1 + 2 *)
+  print (ExprBinOp (1, "+",
+                    ExprMatch (2, PatVar (3, "N"), ExprLit (LitInteger (4, 1))),
+                    ExprMatch (5, PatVar (6, "M"), ExprLit (LitInteger (7, 2)))));
+  [%expect {|
+    ((ExprMatch 2 (PatVar 3 N) (ExprLit (LitInteger 4 1)))
+     (ExprMatch 5 (PatVar 6 M) (ExprLit (LitInteger 7 2)))
+     (ExprBinOp 1 +
+       (ExprLit (LitInteger 4 1))
+       (ExprLit (LitInteger 7 2)))) |}];
+
+  (* input: {N = 1, M = 2} *)
+  (* output: M = 2, N = 1, {1, 2} *)
+  print (ExprTuple (1,
+                    [ExprMatch (2, PatVar (3, "N"), ExprLit (LitInteger (4, 1)));
+                     ExprMatch (5, PatVar (6, "M"), ExprLit (LitInteger (7, 2)))]));
+  [%expect {|
+    ((ExprMatch 5 (PatVar 6 M) (ExprLit (LitInteger 7 2)))
+     (ExprMatch 2 (PatVar 3 N) (ExprLit (LitInteger 4 1)))
+     (ExprTuple 1 (
+       (ExprLit (LitInteger 4 1))
+       (ExprLit (LitInteger 7 2))))) |}];
+
+  (* input: A *)
+  (* output: A *)
+  print (ExprVar (1, "A"));
+  [%expect {| ((ExprVar 1 A)) |}];
+
+  (* input: a *)
+  (* output: a *)
+  print (ExprLit (LitAtom (1, "a")));
+  [%expect {| ((ExprLit (LitAtom 1 a))) |}];


### PR DESCRIPTION
resolves #81 

I added support for match expressions.

### algorithm

Let us consider an expression E = `fun () -> A = B = f(C = 1), f(A + B + C) end` for example.
By `extract_match_expr`, expression E is converted to `fun () -> C = 1, B = f(1), A = f(1), f(A + B + C) end` (= E').
By `expr_of_erlang_expr'` and `expr_of_erlang_exprs`, expression E' is converted to:
```erlang
fun () -> 
  case 1 of
    C -> case f(1) of
           B -> case f(1) of
                  A -> f(A + B + C)
                end
         end
  end
end
```

Although `f(1)` is called multiple times, I suspect it is no problem because fialyzer is a type checker, not a compiler/interpreter.

### minimum prototype

https://gist.github.com/amutake/0dc3e07a58511fed494a5676904d4eea