### PR TITLE
[79] local function definition and call

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -11,14 +11,15 @@ type t =
     | Var of string
     | Tuple of t list
     | App of t * t list
-    | Abs of string list * t
+    | Abs of fun_abst
     | Let of string * t * t
-    | Letrec of (string * t) list * t
+    | Letrec of (string * fun_abst) list * t
     | Case of t * (pattern * t) list
+    | LocalFun of {function_name : string; arity: int}
     | MFA of {module_name: t; function_name: t; arity: t}
     | ListCons of t * t
     | ListNil
-[@@deriving sexp_of]
+and fun_abst = {args: string list; body: t}
 and pattern = pattern' * t
 and pattern' =
     | PatVar of string
@@ -33,7 +34,7 @@ let string_of_t t =
 
 type spec_fun = (Type.t list * Type.t) list
 [@@deriving sexp_of]
-type decl_fun = {specs: spec_fun option; fun_name: string; args: string list; body: t}
+type decl_fun = {specs: spec_fun option; fun_name: string; fun_abst: fun_abst}
 [@@deriving sexp_of]
 type module_ = {
     file : string;

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -2,7 +2,7 @@ open Base
 module Format = Caml.Format
 
 module Key = struct
-  type t = Var of String.t | MFA of Mfa.t
+  type t = Var of String.t | MFA of Mfa.t | LocalFun of {function_name:string; arity: int}
   [@@deriving show, sexp_of]
 end
 

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -2,7 +2,7 @@ open Base
 module Format = Caml.Format
 
 module Key : sig
-  type t = Var of String.t | MFA of Mfa.t
+  type t = Var of String.t | MFA of Mfa.t | LocalFun of {function_name:string; arity: int}
   [@@deriving show, sexp_of]
 end
 

--- a/lib/known_error.ml
+++ b/lib/known_error.ml
@@ -25,6 +25,8 @@ let to_message = function
      !%"Invalid beam format '%s': %s" beam_filename message
   | UnboundVariable {filename; line; variable = Var v; } ->
      !%"%s:%d: Unbound variable: %s" filename line v
+  | UnboundVariable {filename; line; variable = LocalFun {function_name; arity}; } ->
+     !%"%s:%d: Unbound function: %s/%d" filename line function_name arity
   | UnboundVariable {filename; line; variable = MFA mfa; } ->
      !%"%s:%d: Unknown function: %s" filename line (Mfa.show mfa)
   | TypeError errs ->

--- a/test/unit-test/test_derivation.ml
+++ b/test/unit-test/test_derivation.ml
@@ -192,11 +192,11 @@ let%expect_test "derivation" =
           Empty))))
   |}];
 
-  print Context.empty (Abs (["X"], Var "X"));
+  print Context.empty (Abs {args=["X"]; body=Var "X"});
   [%expect {|
     (Ok ("fun((a) -> a)" Empty)) |}];
 
-  print Context.empty (Abs (["x"; "y"; "z"], Var "x"));
+  print Context.empty (Abs {args=["x"; "y"; "z"]; body=Var "x"});
   [%expect {|
     (Ok ("fun((a, b, c) -> a)" Empty))
    |}];
@@ -225,7 +225,7 @@ let%expect_test "derivation" =
           (Subtype 57 b)
           Empty)))) |}];
 
-  print Context.empty (App (Abs (["X"], Var "X"), [Constant (Number 42)]));
+  print Context.empty (App (Abs {args=["X"]; body=Var "X"}, [Constant (Number 42)]));
   [%expect {|
     (Ok (
       d (
@@ -237,7 +237,7 @@ let%expect_test "derivation" =
           Empty))))
     |}];
 
-  print Context.empty (App (Abs (["X"; "Y"], Var "X"), [Constant (Number 42); Constant (Number 57)]));
+  print Context.empty (App (Abs {args=["X"; "Y"]; body=Var "X"}, [Constant (Number 42); Constant (Number 57)]));
   [%expect {|
     (Ok (
       f (
@@ -254,16 +254,16 @@ let%expect_test "derivation" =
   [%expect {|
     (Ok (42 (Conj (Empty Empty)))) |}];
 
-  print Context.empty (Letrec ([("x", Constant (Number 42))], Var "x"));
-  [%expect {| (Ok (a (Conj (Empty (Eq a 42) Empty)))) |}];
+  print Context.empty (Letrec ([("x", {args=[]; body=Constant (Number 42)})], LocalFun {function_name="x"; arity=0}));
+  [%expect {| (Ok (a (Conj (Empty (Eq a "fun(() -> 42)") Empty)))) |}];
 
   print
     Context.empty
     (Letrec
       ([
-        ("f", Abs (["X"], App (Var "g", [Var "X"])));
-        ("g", Abs (["X"], App (Var "f", [Var "X"])))
-      ], App (Var "f", [Constant (Number 42)])));
+        ("f", {args=["X"]; body=App (LocalFun {function_name="g"; arity=1}, [Var "X"])});
+        ("g", {args=["X"]; body=App (LocalFun {function_name="f"; arity=1}, [Var "X"])})
+      ], App (LocalFun {function_name="f"; arity=1}, [Constant (Number 42)])));
   [%expect {|
     (Ok (
       m (

--- a/test/unit-test/test_from_erlang.ml
+++ b/test/unit-test/test_from_erlang.ml
@@ -90,7 +90,7 @@ let%expect_test "from_erlang" =
     ClsFun(1, [PatVar(1, "X")], None, ExprVar(1, "X"))
   ]));
   [%expect {|
-    (Abs (X) (Var X))
+    (Abs ((args (X)) (body (Var X))))
   |}];
 
   (*
@@ -100,7 +100,7 @@ let%expect_test "from_erlang" =
     ClsFun(1, [PatVar(1, "X")], None, ExprLocalCall(1, ExprVar(1, "F"), [ExprVar(1, "X")]))
   ]));
   [%expect {|
-    (Letrec ((F (Abs (X) (App (Var F) ((Var X)))))) (Var F))
+    (Letrec ((F ((args (X)) (body (App (Var F) ((Var X))))))) (Var F))
   |}];
 
   (*
@@ -113,9 +113,10 @@ let%expect_test "from_erlang" =
     ClsFun(1, [PatVar(1, "X"); PatVar(1, "Y")], None, ExprTuple(1, [ExprVar(1, "X"); ExprVar(1, "Y")]))
   ]));
   [%expect {|
-    (Abs
-      (__A__ __B__)
-      (Case
+    (Abs (
+      (args (__A__ __B__))
+      (body (
+        Case
         (Tuple (
           (Var __A__)
           (Var __B__)))
@@ -135,7 +136,7 @@ let%expect_test "from_erlang" =
            (Constant (Atom true)))
           (Tuple (
             (Var X)
-            (Var Y)))))))
+            (Var Y)))))))))
   |}];
 
   (*
@@ -145,13 +146,14 @@ let%expect_test "from_erlang" =
     ClsFun(1, [PatLit (LitAtom(1, "x"))], None, ExprLit(LitAtom(1, "y")))
   ]));
   [%expect {|
-    (Abs
-      (__A__)
-      (Case
+    (Abs (
+      (args (__A__))
+      (body (
+        Case
         (Tuple ((Var __A__)))
         ((
           ((PatTuple ((PatConstant (Atom x)))) (Constant (Atom true)))
-          (Constant (Atom y))))))
+          (Constant (Atom y))))))))
   |}];
 
 
@@ -162,13 +164,14 @@ let%expect_test "from_erlang" =
     ClsFun(1, [PatLit (LitInteger(1, 42))], None, ExprLit(LitInteger(1, 43)))
   ]));
   [%expect {|
-    (Abs
-      (__A__)
-      (Case
+    (Abs (
+      (args (__A__))
+      (body (
+        Case
         (Tuple ((Var __A__)))
         ((
           ((PatTuple ((PatConstant (Number 42)))) (Constant (Atom true)))
-          (Constant (Number 43))))))
+          (Constant (Number 43))))))))
   |}];
 
 
@@ -182,9 +185,10 @@ let%expect_test "from_erlang" =
     ClsFun (2, [PatCons (2, PatVar (2, "H"), PatVar (2, "T"))], None, ExprVar (2, "T"))
   ]));
   [%expect {|
-    (Abs
-      (__A__)
-      (Case
+    (Abs (
+      (args (__A__))
+      (body (
+        Case
         (Tuple ((Var __A__)))
         ((((PatTuple (PatNil)) (Constant (Atom true))) ListNil)
          (((PatTuple ((
@@ -192,7 +196,7 @@ let%expect_test "from_erlang" =
              (PatVar H)
              (PatVar T))))
            (Constant (Atom true)))
-          (Var T))))) |}];
+          (Var T))))))) |}];
 
   (*
    * fun ("abc") -> ok end
@@ -201,9 +205,10 @@ let%expect_test "from_erlang" =
     ClsFun (1, [PatLit (LitString (1, "abc"))], None, ExprLit (LitAtom (1, "ok")))
   ]));
   [%expect {|
-    (Abs
-      (__A__)
-      (Case
+    (Abs (
+      (args (__A__))
+      (body (
+        Case
         (Tuple ((Var __A__)))
         ((
           ((PatTuple ((
@@ -213,7 +218,7 @@ let%expect_test "from_erlang" =
                (PatConstant (Number 98))
                (PatCons (PatConstant (Number 99)) PatNil)))))
            (Constant (Atom true)))
-          (Constant (Atom ok)))))) |}];
+          (Constant (Atom ok)))))))) |}];
 
   (*
    * [1,2,3]
@@ -258,9 +263,10 @@ let%expect_test "from_erlang" =
                                      ExprMatch (1, PatVar (1, "B"), ExprLit (LitInteger (1, 2)));
                                      ExprBinOp (1, "+", ExprVar (1, "A"), ExprVar (1, "B"))])]));
   [%expect {|
-    (Abs
-      ()
-      (Case
+    (Abs (
+      (args ())
+      (body (
+        Case
         (Constant (Number 1))
         ((
           ((PatVar A) (Constant (Atom true)))
@@ -274,7 +280,7 @@ let%expect_test "from_erlang" =
                   (function_name (Constant (Atom   +)))
                   (arity         (Constant (Number 2))))
                 ((Var A)
-                 (Var B)))))))))) |}]
+                 (Var B)))))))))))) |}]
 
 let%expect_test "extract_match_expr" =
   let print expr =

--- a/test/unit-test/test_from_erlang.ml
+++ b/test/unit-test/test_from_erlang.ml
@@ -28,7 +28,7 @@ let%expect_test "code_to_module" =
      ((file test.erl)
       (name test)
       (export ())
-      (functions (((specs ()) (fun_name f) (args (X)) (body (Var X))))))
+      (functions (((specs ()) (fun_name f) (fun_abst ((args (X)) (body (Var X))))))))
   |}];
 
   (* patterns in toplevel *)
@@ -49,14 +49,15 @@ let%expect_test "code_to_module" =
       (functions ((
         (specs ())
         (fun_name f)
-        (args (__A__))
-        (body (
-          Case
-          (Tuple ((Var __A__)))
-          ((((PatTuple ((PatConstant (Atom a)))) (Constant (Atom true)))
-            (Constant (Number 10)))
-           (((PatTuple ((PatConstant (Atom b)))) (Constant (Atom true)))
-            (Constant (Number 20))))))))))
+        (fun_abst (
+          (args (__A__))
+          (body (
+            Case
+            (Tuple ((Var __A__)))
+            ((((PatTuple ((PatConstant (Atom a)))) (Constant (Atom true)))
+              (Constant (Number 10)))
+             (((PatTuple ((PatConstant (Atom b)))) (Constant (Atom true)))
+              (Constant (Number 20))))))))))))
   |}]
 
 let%expect_test "from_erlang" =


### PR DESCRIPTION
- Add `LocalFun` variant to type `Ast.t`
- Convert `func/arity` to `LocalFun{"func"; arity}`
- Convert `func(args)` to `App(LocalFun("func", arity), args)`
- Add `LocalFun` variant to type `Context.Key`
- Refactoring: Make `Letrec` have  function abstractions
- Refactoring: Commonize data of function abstractions that appears in `Abs`, `Letrec` and `decl_fun`