### PR TITLE
obeam-0.1.3

### DIFF
--- a/fialyzer.opam
+++ b/fialyzer.opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "dune" {build}
   "base"
-  "obeam" {= "0.1.2"}
+  "obeam" {= "0.1.3"}
   "bitstring"
   "zarith"
   "ppx_deriving" {build}

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -159,15 +159,15 @@ and inf_elem ty1 ty2 =  (* ty1 and ty2 should be a TyNumber, TySingleton, TyAtom
      None
 
 let rec of_erlang = function
-  | F.TyUnion (_line, ts) ->
-     TyUnion (List.map ~f:elem_of_erlang ts)
+  | F.TyUnion {elements; _} ->
+     TyUnion (List.map ~f:elem_of_erlang elements)
   | t ->
      of_elem (elem_of_erlang t)
 and elem_of_erlang = function
-  | F.TyPredef (_line, "number", []) -> TyNumber
-  | F.TyLit (LitAtom (_, atom)) -> TySingleton (Atom atom)
-  | F.TyVar (_line, v) -> TyVar (Type_variable.of_string v)
-  | TyFun (_line, _, args, range) ->
-     TyFun(List.map ~f:of_erlang args, of_erlang range)
+  | F.TyPredef {name="number"; args=[]; _} -> TyNumber
+  | F.TyLit {lit=LitAtom {atom; _}} -> TySingleton (Atom atom)
+  | F.TyVar {id; _} -> TyVar (Type_variable.of_string id)
+  | TyFun {params; ret; _} ->
+     TyFun(List.map ~f:of_erlang params, of_erlang ret)
   | other ->
      failwith (!%"not implemented conversion from type: %s" (F.sexp_of_type_t other |> Sexp.to_string_hum))

--- a/test/unit-test/test_from_erlang.ml
+++ b/test/unit-test/test_from_erlang.ml
@@ -16,12 +16,13 @@ let%expect_test "code_to_module" =
 
   (* simple module *)
   print (AbstractCode(ModDecl [
-                          AttrFile(line, "test.erl", line);
-                          AttrMod(line, "test");
-                          AttrExport(line, [("f", 1)]);
-                          DeclFun(line, "f", 0, [
-                                      ClsFun(line, [PatVar(line, "X")], None, ExprBody[ExprVar(line, "X")])
-                                 ]);
+                          AttrFile {line; file="test.erl"; file_line=line};
+                          AttrMod {line; module_name="test"};
+                          AttrExport {line; function_arity_list=[("f", 1)]};
+                          DeclFun {line; function_name="f"; arity=0; clauses=[
+                                       ClsFun {line; patterns=[PatVar {line=line; id="X"}]; guard_sequence=None;
+                                               body=ExprBody {exprs=[ExprVar {line; id="X"}]}}
+                                  ]};
                           FormEof
         ]));
   [%expect {|
@@ -33,13 +34,15 @@ let%expect_test "code_to_module" =
 
   (* patterns in toplevel *)
   print (AbstractCode(ModDecl [
-                          AttrFile(line, "patterns.erl", line);
-                          AttrMod(line, "patterns");
-                          AttrExport(line, [("f", 1)]);
-                          DeclFun(line, "f", 0, [
-                                      ClsFun(line, [PatLit(LitAtom(line, "a"))], None, ExprBody[ExprLit(LitInteger(line, 10))]);
-                                      ClsFun(line, [PatLit(LitAtom(line, "b"))], None, ExprBody[ExprLit(LitInteger(line, 20))]);
-                                 ]);
+                          AttrFile {line; file="patterns.erl"; file_line=line};
+                          AttrMod {line; module_name="patterns"};
+                          AttrExport {line; function_arity_list=[("f", 1)]};
+                          DeclFun {line; function_name="f"; arity=0; clauses=[
+                                       ClsFun {line; patterns=[PatLit {lit=LitAtom {line; atom="a"}}]; guard_sequence=None;
+                                               body=ExprBody {exprs=[ExprLit {lit=LitInteger {line; integer=10}}]}};
+                                       ClsFun {line; patterns=[PatLit {lit=LitAtom {line; atom="b"}}]; guard_sequence=None;
+                                               body=ExprBody {exprs=[ExprLit {lit=LitInteger {line; integer=20}}]}};
+                                  ]};
                           FormEof;
         ]));
   [%expect {|


### PR DESCRIPTION
obeam-0.1.3:

- char literal support
- types in `Obeam.Abstract_format` have inline-records now

<del>Currently, CI is failed because [the PR of obeam-0.1.3](https://github.com/ocaml/opam-repository/pull/13291) is not merged yet.</del>
obeam-0.1.3 is released.