### PR TITLE
Improve conversion to type from absform (for spec notations)

### DIFF
--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -316,9 +316,9 @@ let forms_to_functions forms =
     List.find_map ~f:(function
                       | F.SpecFun {function_name; arity; specs; _} when fun_name = function_name ->
                          List.map ~f:(fun ty ->
-                                    match Type.of_erlang ty with
+                                    match Type.of_absform ty with
                                     | Type.(TyUnion [Type.TyFun (domains, range)]) -> (domains, range)
-                                    | _ -> failwith (!%"unexpected type spec of %s" function_name))
+                                    | other -> failwith (!%"unexpected type spec of %s/%d: %s: %s" function_name arity (Type.pp other) (F.sexp_of_type_t ty |> Sexp.to_string_hum)))
                                   specs
                          |> Option.return
                       | _ -> None) forms

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -222,9 +222,4 @@ let rec of_absform = function
      Log.debug [%here] "not implemented conversion from type: %s" (F.sexp_of_type_t other |> Sexp.to_string_hum);
      of_elem (TySingleton (Atom "not_implemented"))
   | F.TyPredef {line; name; args} ->
-     failwith (!%"Prease report: ")
-
-
-let of_absform f =
-  Log.debug [%here] "Type.of_absform: %s" (F.sexp_of_type_t f |> Sexp.to_string_hum);
-  of_absform f
+     failwith (!%"Prease report: line:%d: unexpected predef type: '%s/%d'" line name (List.length args))


### PR DESCRIPTION
- Make it not to be a error when reading of type spec failed
- Make unimplemented parts of `Type.of_absform` easier to understand