### PR TITLE
Store PDFs as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
       - run:
           name: Build PDF
           command: eval $(opam env) && for SATY in $(ls docs/*.saty); do satysfi $SATY; done
+      - store_artifacts:
+          # NOTE: `path` must be a directory or a file. `docs/*.pdf` is invalid.
+          path: docs
       - persist_to_workspace:
           root: .
           paths: docs/*.pdf


### PR DESCRIPTION
How to see generated PDF
-------------

1. Click CircleCI's ✓ mark and click `satysfi` job

<img width="712" alt="2019-02-19 19 33 47" src="https://user-images.githubusercontent.com/1419976/53008763-6f0a1980-347d-11e9-809e-5c6fec75eb60.png">

2. Click `Artifacts` tab and you can find generated PDFs

<img width="1182" alt="2019-02-19 19 34 27" src="https://user-images.githubusercontent.com/1419976/53008772-74676400-347d-11e9-812d-98833c9dd8d0.png">
