### PR TITLE
Refactor unifing function references

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -12,15 +12,13 @@ type line = int
 
 type t =
     | Constant of line * Constant.t
-    | Var of line * string
+    | Ref of line * reference
     | Tuple of line * t list
     | App of line * t * t list
     | Abs of line * fun_abst
     | Let of line * string * t * t
     | Letrec of line * (string * fun_abst) list * t
     | Case of t * (pattern * t) list
-    | LocalFun of {function_name : string; arity: int}
-    | MFA of {module_name: t; function_name: t; arity: t}
     | ListCons of t * t
     | ListNil
     | MapCreation of (t * t) list                  (* #{k1 => v1, ...} *)
@@ -34,19 +32,21 @@ and pattern' =
     | PatCons of pattern' * pattern'
     | PatNil
     | PatMap of (pattern' * pattern') list
+and reference =
+  | Var of string
+  | LocalFun of {function_name : string; arity : int}
+  | MFA of {module_name : t; function_name : t; arity : t}
 [@@deriving sexp_of]
 
 let line_number_of_t = function
 | Constant (line, _) -> line
-| Var (line, _) -> line
+| Ref (line, _) -> line
 | Tuple (line, _) -> line
 | App (line, _, _) -> line
 | Abs (line, _) -> line
 | Let (line, _, _, _) -> line
 | Letrec (_) -> -1
 | Case (_, _) -> -1
-| LocalFun _ -> -1
-| MFA _ -> -1
 | ListCons (_, _) -> -1
 | ListNil -> -1
 | MapCreation _ -> -1

--- a/test/unit-test/test_solver.ml
+++ b/test/unit-test/test_solver.ml
@@ -8,11 +8,11 @@ let sexp_of_solution sol =
   |> [%sexp_of: string Map.M(Type_variable).t]
 
 let eq (ty1, ty2) =
-  let link = Ast.Var (-1, "__dummy_expr__") in
+  let link = Ast.Ref (-1, Var "__dummy_expr__") in
   Constraint.Eq {lhs=ty1; rhs=ty2; link}
 
 let subtype (ty1, ty2) =
-  let link = Ast.Var (-1, "__dummy_expr__") in
+  let link = Ast.Ref (-1, Var "__dummy_expr__") in
   Constraint.Subtype {lhs=ty1; rhs=ty2; link}
 
 let%expect_test "solver" =


### PR DESCRIPTION
- Introduce `reference` type for `Var`, `LocalFun` and `MFA`
- Introduce `Ref of ref` variant to type `ast`
- fix tests