### PR TITLE
Support Multi module

### DIFF
--- a/bin/cui.ml
+++ b/bin/cui.ml
@@ -3,9 +3,11 @@ open Fialyzer
 module Arg = Caml.Arg
 
 type param = {
-    beam_file : string;
+    beam_files : string list;
     plt_file : string option;
   }
+
+let beam_files_ref = ref []
 
 let plt_file_ref = ref None
 
@@ -22,9 +24,8 @@ let work f =
   in
   Arg.parse specs
             (begin fun beam_file ->
-             f {
-                 beam_file;
-                 plt_file = !plt_file_ref;
-               }
+		   beam_files_ref := beam_file :: !beam_files_ref;
              end)
-            usage_msg
+            usage_msg;
+  let param = {beam_files = !beam_files_ref; plt_file = !plt_file_ref} in
+  f param

--- a/bin/cui.mli
+++ b/bin/cui.mli
@@ -1,5 +1,5 @@
 type param = {
-    beam_file : string;
+    beam_files : string list;
     plt_file : string option;
   }
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -65,7 +65,7 @@ let () =
   Cui.work (fun param ->
       try
         Log.debug [%here] "=== start fialyzer ===";
-        let files = [param.Cui.beam_file] in
+        let files = param.Cui.beam_files in
         Result.ok_exn begin
             read_plt param.Cui.plt_file >>= fun plt ->
             result_map_m ~f:module_of_file files >>= fun modules ->

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -27,3 +27,17 @@ let map_add_if_not_exists key data map =
     Map.add_exn ~key ~data map
   else
     map
+
+let list_of_option o =
+  o |> Option.map ~f:(fun x -> [x]) |> Option.value ~default:[]
+
+let list_group_by ~f xs =
+  let open Poly in
+  let rec iter store = function
+    | []  -> List.rev store
+    | x :: xs ->
+      let y = f x in
+      let (xs', rest) = List.partition_tf ~f:(fun x' -> f x' = y) xs in
+      iter ((y, x::xs') :: store) rest
+  in
+  iter [] xs

--- a/lib/common.mli
+++ b/lib/common.mli
@@ -10,3 +10,7 @@ val (<<<) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
 val (>>>) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 
 val map_add_if_not_exists : 'a -> 'b -> ('a, 'b, 'c) Map.t -> ('a, 'b, 'c) Map.t
+
+val list_of_option : 'a option -> 'a list
+
+val list_group_by : f:('a -> 'b) -> 'a list -> ('b * 'a list) list

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -11,6 +11,7 @@ module MapOnKey = Poly_map.Make(Key)
 
 (*type t = typ Map.M(Key).t*)
 type t = Type.t MapOnKey.t
+[@@deriving sexp_of]
 
 let empty : t = MapOnKey.empty
 let find = Map.find

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -7,6 +7,7 @@ module Key : sig
 end
 
 type t
+[@@deriving sexp_of]
 
 val empty : t
 val find : t -> Key.t -> Type.t option

--- a/lib/type_check.ml
+++ b/lib/type_check.ml
@@ -13,7 +13,16 @@ let check_module plt ctx m =
 
 let check_modules plt modules =
   let import_modules = ["erlang"] in (*TODO: https://github.com/dwango/fialyzer/issues/166 *)
-  let ctx = Context.create ~import_modules plt in (*TODO: https://github.com/dwango/fialyzer/issues/167 *)
+  let specs =
+    modules
+    |> List.concat_map ~f:Ast.specs_of_module
+  in
+  let ctx0 = Context.create ~import_modules plt in (*TODO: https://github.com/dwango/fialyzer/issues/167 *)
+  let ctx =
+    List.fold_left ~f:(fun ctx (mfa, ty) ->
+			   Context.add (Context.Key.MFA mfa) ty ctx)
+                   ~init:ctx0 specs
+  in
   let open Result in
   result_map_m ~f:(check_module plt ctx) modules >>= fun _ ->
   Result.return ()

--- a/test/unit-test/test_common.ml
+++ b/test/unit-test/test_common.ml
@@ -15,3 +15,29 @@ let%expect_test "result_map_m" =
 
   print (function 1 -> Ok 1 | _ -> Error "Not One") [1; 2; 3];
   [%expect {| (Error "Not One") |}];
+
+  ()
+
+let%expect_test "list_group_by" =
+  let print f xs =
+    list_group_by ~f xs
+    |> [%sexp_of: (int * string list) list]
+    |> Expect_test_helpers_kernel.print_s
+  in
+
+  print String.length [];
+  [%expect {|()|}];
+
+  print String.length [""; "a"; "ab"; "abc"; "xy"; "z"];
+  [%expect {|
+    ((0 (""))
+     (1 (a  z))
+     (2 (ab xy))
+     (3 (abc)))
+    |}];
+
+  let const a b = a in
+  print (const 0) [""; "a"; "ab"];
+  [%expect {| ((0 ("" a ab))) |}];
+
+  ()


### PR DESCRIPTION
fix #167 

## Example

```mod_a.erl
-module(mod_a).

-export([f/0, h/1, main/0]).

main() ->
  h(mod_b:g(f())).

-spec f() -> ok.
f() -> ok.

-spec h(number()) -> boolean().
h(Num) ->
   (Num and true) =:= 123.
```

```mod_b.erl
-module(mod_b).

-export([g/1]).

-spec g(ok | error) -> number().
g(X) ->
    1.
```

```console
erlc +debug_info mod_a.erl
erlc +debug_info mod_b.erl
_build/default/bin/main.exe --debug mod_a.beam mod_b.beam
```

```
2019-04-11T12:11:19 (bin/main.ml:67:18) === start fialyzer ===
...
TODO:filename:-1: Type error: type mismatch;
  found   : number()
  required: 'true' | 'false'
there is no solution that satisfies subtype constraints
```