### PR TITLE
Support catch expr

### DIFF
--- a/docs/derivation-rules.saty
+++ b/docs/derivation-rules.saty
@@ -224,7 +224,7 @@ but extended by remote call, local call, list, etc.
           \derive?:{\paren{\mathsc{CATCH}}}{
             | \judgement{A}{e}{\tau}{C} |
           }{
-            \judgement{A}{\mathtt!{catch}\(e\)}{\mathtt!{any\(\)}}{C}
+            \judgement{A}{\mathtt!{catch}\ e}{\mathtt!{any\(\)}}{C}
           }
         }
       );

--- a/docs/derivation-rules.saty
+++ b/docs/derivation-rules.saty
@@ -218,6 +218,17 @@ but extended by remote call, local call, list, etc.
         }
       );
     >
+    +small-block<
+      +math(
+        ${
+          \derive?:{\paren{\mathsc{CATCH}}}{
+            | \judgement{A}{e}{\tau}{C} |
+          }{
+            \judgement{A}{\mathtt!{catch}\(e\)}{\mathtt!{any\(\)}}{C}
+          }
+        }
+      );
+    >
     +section{Differences from the original paper}<
       +p{
         The differences from the derivation rules on the original paper are as follows.

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -24,6 +24,7 @@ type t =
     | ListNil of line
     | MapCreation of (t * t) list                  (* #{k1 => v1, ...} *)
     | MapUpdate of {map: t; assocs: (t * t) list; exact_assocs: (t * t) list} (* M#{k1 => v1, ..., ke1 := ve1, ...} *)
+    | Catch of line * t
 and fun_abst = {args: string list; body: t}
 and pattern = pattern' * t
 and pattern' =
@@ -52,6 +53,7 @@ let line_number_of_t = function
 | ListNil line -> line
 | MapCreation _ -> -1
 | MapUpdate _ -> -1
+| Catch (line, _) -> line
 
 let string_of_t t =
   [%sexp_of: t] t |> Sexplib.Sexp.to_string_hum ~indent:2

--- a/lib/derivation.ml
+++ b/lib/derivation.ml
@@ -194,6 +194,9 @@ let rec derive context = function
      (* TODO: fully support map update. see: https://github.com/dwango/fialyzer/issues/102#issuecomment-461787511 *)
      derive context map >>= fun (ty_map, c_map) ->
      Ok (Type.of_elem TyAnyMap, C.Conj [c_map; C.Subtype {lhs=ty_map; rhs=Type.of_elem TyAnyMap; link=map}])
+  | Catch (line, body) ->
+     derive context body >>= fun (_, c) ->
+     Ok (Type.TyAny, c)
 and derive_pattern context pattern = 
     begin match pattern with
     | PatVar _ | PatTuple _ | PatConstant _ | PatCons (_, _) | PatNil ->

--- a/lib/from_erlang.ml
+++ b/lib/from_erlang.ml
@@ -320,9 +320,9 @@ and expr_of_erlang_expr' = function
           failwith "cannot reach here"
     ) in
     Case (line, expr_of_erlang_expr' expr, cs)
-  | ExprCatch _ ->
-     raise Known_error.(FialyzerError (NotImplemented {issue_links=["https://github.com/dwango/fialyzer/issues/223"];
-                                                       message="support catch expr"}))
+  | ExprCatch {line; expr} ->
+     let e = expr_of_erlang_expr' expr in
+     Catch (line, e)
   | ExprLocalFunRef {line; function_name; arity} ->
      Ref(line, LocalFun {function_name; arity})
   | ExprRemoteFunRef {line; module_name; function_name; arity} ->

--- a/test/blackbox-test/test-cases/try_catch_expr.erl
+++ b/test/blackbox-test/test-cases/try_catch_expr.erl
@@ -1,0 +1,8 @@
+-module(try_catch_expr).
+
+-export([main/0]).
+
+-spec main() -> any().
+main() ->
+    catch 1 + 2.
+    

--- a/test/blackbox-test/test-cases/try_catch_expr.expected
+++ b/test/blackbox-test/test-cases/try_catch_expr.expected
@@ -1,0 +1,1 @@
+done (passed successfully)


### PR DESCRIPTION
## What are catch expressions in Erlang

see http://erlang.org/doc/reference_manual/expressions.html#catch-and-throw

## Derivation rules

```
Γ |- e : τ, C
-------------------------------[CATCH]
Γ |- catch e : any(), C
```

## Generated PDF

https://1275-87309195-gh.circle-artifacts.com/0/home/opam/fialyzer/docs/derivation-rules.pdf
(via https://circleci.com/gh/dwango/fialyzer/1275#artifacts/containers/0 )

## Don't we need to support `throw` expressions?

`throw` is a BIF(built-in function). see https://github.com/dwango/fialyzer/issues/196