### PR TITLE
Support try expression

### DIFF
--- a/test/blackbox-test/test-cases/try_catch_expr.erl
+++ b/test/blackbox-test/test-cases/try_catch_expr.erl
@@ -1,8 +1,34 @@
 -module(try_catch_expr).
 
--export([main/0]).
+-export([catch_expr/0, expr_try1/0, expr_try2/0, expr_try3/0]).
 
--spec main() -> any().
-main() ->
+-spec catch_expr() -> any().
+catch_expr() ->
     catch 1 + 2.
-    
+
+
+-spec expr_try1() -> number().
+expr_try1() ->
+    try
+        1 + 2
+    catch
+        Err:Stack -> {hoge, Err, Stack}
+    end.
+
+-spec expr_try2() -> number().
+expr_try2() ->
+    try 1 + 2 of
+        X -> 2 * X
+    catch
+        Err:Stack -> {hoge, Err, Stack}
+    end.
+
+-spec expr_try3() -> ok.
+expr_try3() ->
+    try 1 + 2 of
+        X -> 2 * X
+    catch
+        Err:Stack -> {hoge, Err, Stack}
+    after
+        ok
+    end.


### PR DESCRIPTION
Fix https://github.com/dwango/fialyzer/issues/223
This is a simple implementation of `try expression` and does not support `catch clauses`.

* Does not change `Ast.t`
* All `catch clauses` are ignored
* Translate `try expression` to a case expression or a more simple expressions

For the full support of `try` expression, implements about `catch clauses` : https://github.com/dwango/fialyzer/issues/252.


### simple try expressions

```ocaml
    try
        <exprs>
    catch
        <catch-clauses>
    end.
```
↓
```ocaml
[<exprs>]
```

### try expressions with pattern clauses (with an `of` section)

```ocaml
    try
        <exprs>
    of
        <case-clauses>
    catch
        <catch-clauses>
    end.
```
↓
```ocaml
Case(line, [<exprs>], [<case-clauses>])
```

### try expressions with an `after` section

```ocaml
    try
        <exprs>
    catch
        <catch-clauses>
    after
        <after>
    end.
```
↓
```ocaml
Let(line, "_", [<exprs>], [<after>])
```