### PR TITLE
Adapt test.sh to bash3

### DIFF
--- a/test/blackbox-test/test.sh
+++ b/test/blackbox-test/test.sh
@@ -8,12 +8,18 @@ plt=$2
 dir="test-cases"
 performance="performance.log"
 
+do_fialyzer() { # $1 = beam, $2 = output
+    $fialyzer --plt $plt $1 > $2 2>&1
+}
+
 date "+%Y-%m-%d-%H:%M:%S" > $performance
 for beam in $(ls ${dir}/*.beam); do
   echo $beam >> $performance
   testname=$(basename $beam .beam)
   expected="${dir}/${testname}.expected"
   output="${dir}/${testname}.output"
-  time ($fialyzer --plt $plt $beam &> $output) &>> $performance || true
+  # We need the following `true` to circumvent that this script fails due to an error caused by fialyzer.
+  # In this script, we are only interested in the results of diffs.
+  (time (do_fialyzer $beam $output) >> $performance 2>&1) || true
   diff -u $expected $output
 done


### PR DESCRIPTION
# Problem
This PR adapts `test/blackbox-test/test.sh` to bash 3.x.
The motivation is that Mac 10.13 only has bash 3.2, but the original `test.sh` uses functions introduced by bash 4.x.

# Description
By default, Mac 10.13 only has bash 3.2.
```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.13.6
BuildVersion:	17G7024

$ bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)
Copyright (C) 2007 Free Software Foundation, Inc.
```

Since bash 3.x does not allow the syntax `&>>` introduced by bash 4.0,
this PR rewrites the fragment of the code that uses `&>>` in the old way.
(c.f: http://tiswww.case.edu/php/chet/bash/NEWS)

Furthermore, this PR adds a comment to explain why we use `... || true`.