### PR TITLE
Support pid, port, reference, and identifier types

### DIFF
--- a/lib/bif.ml
+++ b/lib/bif.ml
@@ -170,6 +170,8 @@ let type_sigs = [
      Type.(of_elem (TyFun ([], pid))));
     ({module_name="erlang"; function_name="is_process_alive"; arity=1},
      Type.(of_elem (TyFun ([pid], bool))));
+    ({module_name="erlang"; function_name="unlink"; arity=1},
+     Type.(of_elem (TyFun ([TyUnion [TyPid; TyPort]], of_elem (TySingleton (Atom "true"))))));
 
     (* port *)
     ({module_name="erlang"; function_name="list_to_port"; arity=1},

--- a/lib/bif.ml
+++ b/lib/bif.ml
@@ -1,6 +1,10 @@
 open Mfa
 
 let number = Type.(of_elem TyNumber)
+let string = Type.(of_elem (TyList (of_elem TyNumber)))
+let pid = Type.(of_elem TyPid)
+let port = Type.(of_elem TyPort)
+let reference = Type.(of_elem TyReference)
 let pos_integer = Type.(of_elem TyNumber) (*TODO*)
 let non_neg_integer = Type.(of_elem TyNumber) (*TODO*)
 let atom s = Type.(of_elem (TySingleton (Atom s)))
@@ -160,4 +164,16 @@ let type_sigs = [
      Type.(of_elem (TyFun ([of_elem TyAnyMap], number))));
     ({module_name="maps"; function_name="update"; arity=3},
      Type.(of_elem (TyFun ([TyAny; TyAny; any_map], any_map))));
+
+    (* pid *)
+    ({module_name="erlang"; function_name="self"; arity=0},
+     Type.(of_elem (TyFun ([], pid))));
+
+    (* port *)
+    ({module_name="erlang"; function_name="list_to_port"; arity=1},
+     Type.(of_elem (TyFun ([string], port))));
+
+    (* reference *)
+    ({module_name="erlang"; function_name="make_ref"; arity=0},
+     Type.(of_elem (TyFun ([], reference))));
   ]

--- a/lib/bif.ml
+++ b/lib/bif.ml
@@ -168,12 +168,18 @@ let type_sigs = [
     (* pid *)
     ({module_name="erlang"; function_name="self"; arity=0},
      Type.(of_elem (TyFun ([], pid))));
+    ({module_name="erlang"; function_name="is_process_alive"; arity=1},
+     Type.(of_elem (TyFun ([pid], bool))));
 
     (* port *)
     ({module_name="erlang"; function_name="list_to_port"; arity=1},
      Type.(of_elem (TyFun ([string], port))));
+    ({module_name="erlang"; function_name="port_to_list"; arity=1},
+     Type.(of_elem (TyFun ([port], string))));
 
     (* reference *)
     ({module_name="erlang"; function_name="make_ref"; arity=0},
      Type.(of_elem (TyFun ([], reference))));
+    ({module_name="erlang"; function_name="ref_to_list"; arity=1},
+     Type.(of_elem (TyFun ([reference], string))));
   ]

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -88,13 +88,13 @@ and sup_elems_to_list store = function
      sup_elems_to_list store' ty1s
   | TyPid :: ty1s ->
      let store' = List.filter ~f:(function TyPid -> false | _ -> true) store in
-     sup_elems_to_list store' ty1s
+     sup_elems_to_list (TyPid :: store') ty1s
   | TyPort :: ty1s ->
      let store' = List.filter ~f:(function TyPort -> false | _ -> true) store in
-     sup_elems_to_list store' ty1s
+     sup_elems_to_list (TyPort :: store') ty1s
   | TyReference :: ty1s ->
      let store' = List.filter ~f:(function TyReference -> false | _ -> true) store in
-     sup_elems_to_list store' ty1s
+     sup_elems_to_list (TyReference :: store') ty1s
   | TySingleton (Number n) :: ty1s when List.exists ~f:((=) TyNumber) store ->
      sup_elems_to_list store ty1s
   | TySingleton (Number n) :: ty1s ->

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -248,9 +248,12 @@ let rec of_absform = function
   | F.TyAnyMap _ -> of_elem TyAnyMap
   | F.TyPredef {name="string"; args=[]; _} ->
      of_elem (TyList (of_elem TyNumber))
-  | F.TyPredef {name="pid"; args=[]; _}
-  | F.TyPredef {name="port"; args=[]; _}
-  | F.TyPredef {name="reference"; args=[]; _}
+  | F.TyPredef {name="pid"; args=[]; _} ->
+     of_elem TyPid
+  | F.TyPredef {name="port"; args=[]; _} ->
+     of_elem TyPort
+  | F.TyPredef {name="reference"; args=[]; _} ->
+     of_elem TyReference
   | F.TyPredef {name="binary"; args=[]; _}
   | F.TyPredef {name="bitstring"; args=[]; _}
   | F.TyPredef {name="byte"; args=[]; _}

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -304,7 +304,8 @@ let rec of_absform = function
   | F.TyPredef {name="module"; args=[]; _}
   | F.TyPredef {name="mfa"; args=[]; _}
   | F.TyPredef {name="arity"; args=[]; _}
-  | F.TyPredef {name="identifier"; args=[]; _}
+  | F.TyPredef {name="identifier"; args=[]; _} ->
+     TyUnion [TyPid; TyPort; TyReference]
   | F.TyPredef {name="node"; args=[]; _}
   | F.TyPredef {name="timeout"; args=[]; _}
   | F.TyPredef {name="no_return"; args=[]; _}

--- a/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref.erl
+++ b/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref.erl
@@ -1,0 +1,19 @@
+-module(identifier_is_union_of_pid_port_ref).
+-export([main/0]).
+
+-spec gen_ident1() -> identifier().
+gen_ident1() ->
+    self().
+
+-spec gen_ident2() -> identifier().
+gen_ident2() ->
+    list_to_port("test").
+
+-spec gen_ident3() -> identifier().
+gen_ident3() ->
+    make_ref().
+
+main() ->
+    gen_ident1(),
+    gen_ident2(),
+    gen_ident3().

--- a/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref.expected
+++ b/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref.expected
@@ -1,0 +1,1 @@
+done (passed successfully)

--- a/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref_error.erl
+++ b/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref_error.erl
@@ -1,0 +1,9 @@
+-module(identifier_is_union_of_pid_port_ref_error).
+-export([main/0]).
+
+-spec wrong_gen_ident() -> identifier().
+wrong_gen_ident() ->
+    false.
+
+main() ->
+    wrong_gen_ident().

--- a/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref_error.expected
+++ b/test/blackbox-test/test-cases/identifier_is_union_of_pid_port_ref_error.expected
@@ -1,0 +1,3 @@
+test-cases/identifier_is_union_of_pid_port_ref_error.erl:-1: wrong_gen_ident: Type spec unmatch;
+  success type: fun(() -> 'false')
+  type spec   : fun(() -> pid() | port() | reference())

--- a/test/blackbox-test/test-cases/pid_reference_conflict_error.erl
+++ b/test/blackbox-test/test-cases/pid_reference_conflict_error.erl
@@ -1,0 +1,6 @@
+-module(pid_reference_conflict_error).
+-export([main/1]).
+
+main(X) ->
+    ref_to_list(X),
+    is_process_alive(X).

--- a/test/blackbox-test/test-cases/pid_reference_conflict_error.expected
+++ b/test/blackbox-test/test-cases/pid_reference_conflict_error.expected
@@ -1,0 +1,4 @@
+TODO:filename:6: Type error: type mismatch;
+  found   : reference()
+  required: pid()
+there is no solution that satisfies subtype constraints

--- a/test/blackbox-test/test-cases/sup_pid_port.erl
+++ b/test/blackbox-test/test-cases/sup_pid_port.erl
@@ -1,0 +1,6 @@
+-module(sup_pid_port).
+-export([main/1]).
+
+main(X) ->
+    true = unlink(self()), % unlink : Pid | Port -> true
+    true = unlink(list_to_port(X)).

--- a/test/blackbox-test/test-cases/sup_pid_port.expected
+++ b/test/blackbox-test/test-cases/sup_pid_port.expected
@@ -1,0 +1,1 @@
+done (passed successfully)


### PR DESCRIPTION
Question: which one of the following is the correct definition?
1. `sup(TyPid, TyPort) = TyPid | TyPort`
2. `sup(TyPid, TyPort) = TyIdentifier`