### PR TITLE
Patch for issue275

### DIFF
--- a/bin/cui.ml
+++ b/bin/cui.ml
@@ -1,13 +1,39 @@
 open Base
 open Fialyzer
+module Filename = Caml.Filename
 module Arg = Caml.Arg
+
+let make_tempdir () =
+  let tmp_file = Filename.temp_file "xxxxx" "yyyyyy" in
+  Filename.dirname tmp_file
+
+let check_if_erlc_exists () =
+  match Unix.system "which erlc > /dev/null" with
+  | WEXITED status -> status = 0
+  | WSIGNALED _
+  | WSTOPPED _ -> false
+
+let compile_erl_to_beam erl_file =
+  let tempdir_path = make_tempdir () in
+  let command = Printf.sprintf "erlc +debug_info -o %s %s" tempdir_path erl_file in
+  let beam_file_name = Filename.concat tempdir_path ((Filename.chop_extension erl_file) ^ ".beam") in
+  (beam_file_name, Unix.system command)
+
+let rec compile_erl_files erl_files =
+  match erl_files with
+  | [] -> []
+  | x :: xs ->
+     let (file_name, status) = compile_erl_to_beam x in
+     match status with
+     | WEXITED status when status = 0 -> file_name :: compile_erl_files xs
+     | _ -> failwith (Printf.sprintf "compiling the file `%s` failed" file_name)
 
 type param = {
     beam_files : string list;
     plt_file : string option;
   }
 
-let beam_files_ref = ref []
+let files_ref = ref []
 
 let plt_file_ref = ref None
 
@@ -16,16 +42,28 @@ let set_plt_file plt_file =
 
 let usage_msg = "Usage: fialyzer <beam_filename>"
 
+let use_erl_file_ref = ref false
+
 let work f =
   let specs = [
+      ("--src", Arg.Set use_erl_file_ref, "Analyze erlang source codes directly");
       ("--plt", Arg.String set_plt_file, "Use the specified plt as the initial plt");
       ("--debug", Arg.Set Log.debug_mode , "Print debug logs");
     ]
   in
   Arg.parse specs
-            (begin fun beam_file ->
-		   beam_files_ref := beam_file :: !beam_files_ref;
+            (begin fun file ->
+		   files_ref := file :: !files_ref;
              end)
             usage_msg;
-  let param = {beam_files = !beam_files_ref; plt_file = !plt_file_ref} in
+  let param =
+    if !use_erl_file_ref then
+        if check_if_erlc_exists () then
+          let compiled_beam_files = compile_erl_files !files_ref in
+          {beam_files = compiled_beam_files; plt_file = !plt_file_ref}
+        else
+          failwith "to use --src option, please install `erlc` command."
+    else
+      {beam_files = !files_ref; plt_file = !plt_file_ref}
+  in
   f param


### PR DESCRIPTION
# Motivation
See issue #275 .

# Effect
Applying this PR, we can do the following:
```
% fialyzer --src prog1.erl
...
% fialyzer --src prog2.erl prog3.erl
```

However, at this time, we do not permit the following form where there are both erlang and beam files:
```
% fialyzer --src prog1.erl prog2.beam
```

# Implementation
1. Make a temporary directory (we call this `X`)
2. Compile given erlang files and move obtained beam files to `X`
3. pass the beam files in `X` to the main process of the current Fialyzer.